### PR TITLE
Replace wildcard mockito dependency for pom validation

### DIFF
--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testCompile 'com.google.testing.compile:compile-testing:0.5'
     testCompile 'org.slf4j:slf4j-api:1.7.6'
     testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
-    testCompile "org.mockito:mockito-core:1.+"
+    testCompile "org.mockito:mockito-core:1.10.19"
 }
 
 cobertura {


### PR DESCRIPTION
To release to sonatype we need to remove wildcard dependencies.