### PR TITLE
Adds @Validator to facilitate nullness assumptions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -69,8 +69,8 @@ final class AnnotationWriter {
     private final boolean hasNonNullOrNullable;
 
     /**
-     * @param typeMirror the {@link TypeMirror} of the class being evalutated.
-     * @param builder the {@link com.squareup.javapoet.MethodSpec.Builder} that is used to generate the code.
+     * @param typeMirror the {@link TypeMirror} of the class being evaluated.
+     * @param builder the {@link MethodSpec.Builder} that is used to generate the code.
      * @param getter the {@link MethodSpec} for the getter method being evaluated.
      * @param isNullable true if the method DOES NOT have have a {@link NonNull} annotation.
      * @param hasNonNullOrNullable true if either {@link NonNull} or {@link Nullable} annotations are present on the

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -38,7 +38,6 @@ final class MethodIR {
     /**
      * Create a new methodir object.
      * @param getterName the name of the method getter that this IR represents.
-     *
      */
     MethodIR(@NonNull String getterName) {
         annotations = new HashMap<>();

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -34,17 +34,15 @@ import java.util.Map;
 final class MethodIR {
     @NonNull private final Map<Class<? extends Annotation>, Annotation> annotations;
     @NonNull private final String getterName;
-    private final boolean isReturnTypePrimitive;
 
     /**
      * Create a new methodir object.
      * @param getterName the name of the method getter that this IR represents.
-     * @param isReturnTypePrimitive whether the method return type is a primative.
+     *
      */
-    MethodIR(@NonNull String getterName, boolean isReturnTypePrimitive) {
+    MethodIR(@NonNull String getterName) {
         annotations = new HashMap<>();
         this.getterName = getterName;
-        this.isReturnTypePrimitive = isReturnTypePrimitive;
     }
 
     /**
@@ -71,13 +69,6 @@ final class MethodIR {
      */
     boolean hasAnnotation(@NonNull Class<? extends Annotation> cls) {
         return annotations.containsKey(cls);
-    }
-
-    /**
-     * @return {@code true} if the return type of the method is a primitive, false otherwise.
-     */
-    boolean isReturnTypePrimitive() {
-        return isReturnTypePrimitive;
     }
 
     /**

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -34,17 +34,17 @@ import java.util.Map;
 final class MethodIR {
     @NonNull private final Map<Class<? extends Annotation>, Annotation> annotations;
     @NonNull private final String getterName;
-    private final boolean isPrimative;
+    private final boolean isReturnTypePrimitive;
 
     /**
      * Create a new methodir object.
      * @param getterName the name of the method getter that this IR represents.
-     * @param isPrimative whether the method return type is a primative.
+     * @param isReturnTypePrimitive whether the method return type is a primative.
      */
-    MethodIR(@NonNull String getterName, boolean isPrimative) {
+    MethodIR(@NonNull String getterName, boolean isReturnTypePrimitive) {
         annotations = new HashMap<>();
         this.getterName = getterName;
-        this.isPrimative = isPrimative;
+        this.isReturnTypePrimitive = isReturnTypePrimitive;
     }
 
     /**
@@ -74,10 +74,10 @@ final class MethodIR {
     }
 
     /**
-     * @return {@code true} if the return type of the method is a primative, false otherwise.
+     * @return {@code true} if the return type of the method is a primitive, false otherwise.
      */
-    boolean isPrimative() {
-        return isPrimative;
+    boolean isReturnTypePrimitive() {
+        return isReturnTypePrimitive;
     }
 
     /**

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -34,14 +34,17 @@ import java.util.Map;
 final class MethodIR {
     @NonNull private final Map<Class<? extends Annotation>, Annotation> annotations;
     @NonNull private final String getterName;
+    private final boolean isPrimative;
 
     /**
      * Create a new methodir object.
      * @param getterName the name of the method getter that this IR represents.
+     * @param isPrimative whether the method return type is a primative.
      */
-    MethodIR(@NonNull String getterName) {
+    MethodIR(@NonNull String getterName, boolean isPrimative) {
         annotations = new HashMap<>();
         this.getterName = getterName;
+        this.isPrimative = isPrimative;
     }
 
     /**
@@ -68,6 +71,13 @@ final class MethodIR {
      */
     boolean hasAnnotation(@NonNull Class<? extends Annotation> cls) {
         return annotations.containsKey(cls);
+    }
+
+    /**
+     * @return {@code true} if the return type of the method is a primative, false otherwise.
+     */
+    boolean isPrimative() {
+        return isPrimative;
     }
 
     /**

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveIR.java
@@ -22,6 +22,7 @@ package com.uber.rave.compiler;
 
 import android.support.annotation.NonNull;
 
+import com.uber.rave.Validator;
 import com.uber.rave.annotation.Validated;
 
 import java.util.ArrayList;
@@ -39,15 +40,18 @@ final class RaveIR {
     @NonNull private final List<ClassIR> classIRs = new ArrayList<>();
     @NonNull private final String packageName;
     @NonNull private final String simpleName;
+    @NonNull private final Validator.Mode mode;
 
     /**
      * Create a new RAVE IR.
      * @param packageName the package name of the class that will be generted.
      * @param simpleName the simple name of the class to be generated.
+     * @param mode the validation mode to be applied when generating validation code.
      */
-    RaveIR(@NonNull String packageName, @NonNull String simpleName) {
+    RaveIR(@NonNull String packageName, @NonNull String simpleName, @NonNull Validator.Mode mode) {
         this.packageName = packageName;
         this.simpleName = simpleName;
+        this.mode = mode;
     }
 
     /**
@@ -87,5 +91,13 @@ final class RaveIR {
     @NonNull
     String getSimpleName() {
         return simpleName;
+    }
+
+    /**
+     * @return The validation mode for this library.
+     */
+    @NonNull
+    Validator.Mode getMode() {
+        return mode;
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -135,7 +135,7 @@ public final class RaveProcessor extends AbstractProcessor {
      */
     private void process(@NonNull RaveIR raveIR, @NonNull List<TypeElement> allTypes) {
         for (TypeElement typeElement : allTypes) {
-            raveIR.addClassIR(extractClassInfo(typeElement));
+            raveIR.addClassIR(extractClassInfo(typeElement, raveIR.getMode()));
         }
     }
 
@@ -148,7 +148,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @return the {@link ClassIR} object representing the type element.
      */
     @NonNull
-    private ClassIR extractClassInfo(@NonNull TypeElement typeElement) {
+    private ClassIR extractClassInfo(@NonNull TypeElement typeElement, Validator.Mode mode) {
         ClassIR classIR = new ClassIR(typesUtils.erasure(typeElement.asType()));
         traverseInheritanceTree(typeElement, classIR);
         List<ExecutableElement> methodElements = new ImmutableList.Builder<ExecutableElement>()
@@ -177,6 +177,12 @@ public final class RaveProcessor extends AbstractProcessor {
                         methodIR.addAnnotation(annotation);
                     }
                 }
+            }
+            if (mode == Validator.Mode.STRICT
+                    && !methodIR.hasAnnotation(NonNull.class)
+                    && !methodIR.hasAnnotation(Nullable.class)
+                    && !methodIR.isReturnTypePrimitive()) {
+                methodIR.addAnnotation(() -> NonNull.class);
             }
             classIR.addMethodIR(methodIR);
         }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -148,7 +148,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @return the {@link ClassIR} object representing the type element.
      */
     @NonNull
-    private ClassIR extractClassInfo(@NonNull TypeElement typeElement, Validator.Mode mode) {
+    private ClassIR extractClassInfo(@NonNull TypeElement typeElement, @NonNull Validator.Mode mode) {
         ClassIR classIR = new ClassIR(typesUtils.erasure(typeElement.asType()));
         traverseInheritanceTree(typeElement, classIR);
         List<ExecutableElement> methodElements = new ImmutableList.Builder<ExecutableElement>()
@@ -163,8 +163,7 @@ public final class RaveProcessor extends AbstractProcessor {
             if (!executableElement.getModifiers().contains(Modifier.PUBLIC) && !samePackage) {
                 continue;
             }
-            MethodIR methodIR = new MethodIR(executableElement.getSimpleName().toString(),
-                    executableElement.getReturnType().getKind().isPrimitive());
+            MethodIR methodIR = new MethodIR(executableElement.getSimpleName().toString());
             for (AnnotationMirror mirror : elementUtils.getAllAnnotationMirrors(executableElement)) {
                 String annotationName = mirror.getAnnotationType().toString();
                 if (CompilerUtils.annotationsIsSupported(mirror.getAnnotationType().toString())) {
@@ -181,7 +180,7 @@ public final class RaveProcessor extends AbstractProcessor {
             if (mode == Validator.Mode.STRICT
                     && !methodIR.hasAnnotation(NonNull.class)
                     && !methodIR.hasAnnotation(Nullable.class)
-                    && !methodIR.isReturnTypePrimitive()) {
+                    && !executableElement.getReturnType().getKind().isPrimitive()) {
                 methodIR.addAnnotation(() -> NonNull.class);
             }
             classIR.addMethodIR(methodIR);

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
@@ -41,7 +41,6 @@ import com.uber.rave.BaseValidator;
 import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
-import com.uber.rave.Validator;
 import com.uber.rave.annotation.MustBeFalse;
 import com.uber.rave.annotation.MustBeTrue;
 
@@ -157,7 +156,7 @@ final class RaveWriter {
         builder.endControlFlow();
         List<MethodSpec> concreteSpecs = new ArrayList<>(raveIR.getNumClasses());
         for (ClassIR classIR : raveIR.getClassIRs()) {
-            MethodSpec specificSpec = generateConcreteMethodSpec(raveIR, classIR);
+            MethodSpec specificSpec = generateConcreteMethodSpec(classIR);
             concreteSpecs.add(specificSpec);
             builder.beginControlFlow("if ($L.equals($T.class))", VALIDATE_METHOD_CLAZZ_ARG_NAME,
                     classIR.getTypeMirror());
@@ -180,12 +179,11 @@ final class RaveWriter {
      * Generate a {@link MethodSpec} for a specific type. This generates the private method within the generated class
      * that validates the object as a specific type.
      *
-     * @param raveIR the intermediate representation of the library.
      * @param classIR the type to generate a method for.
      * @return the {@link MethodSpec} to validate the given specific class.
      */
     @NonNull
-    private MethodSpec generateConcreteMethodSpec(@NonNull RaveIR raveIR, @NonNull ClassIR classIR) {
+    private MethodSpec generateConcreteMethodSpec(@NonNull ClassIR classIR) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder(VALIDATE_METHOD_NAME)
                 .addException(RAVE_INVALID_MODEL_EXCEPTION_CLASS)
                 .addModifiers(Modifier.PRIVATE)
@@ -204,7 +202,7 @@ final class RaveWriter {
                     VALIDATE_METHOD_ARG_NAME, EXCLUSION_STRATEGY_MAP_ARG_NAME);
         }
         for (MethodIR methodIR : classIR.getAllMethods()) {
-            buildAnnotationChecks(builder, raveIR, methodIR, classIR.getTypeMirror());
+            buildAnnotationChecks(builder, methodIR, classIR.getTypeMirror());
         }
         builder.beginControlFlow("if ($L != null && !$L.isEmpty())", RAVE_ERROR_ARG_NAME,
                 RAVE_ERROR_ARG_NAME);
@@ -214,28 +212,13 @@ final class RaveWriter {
     }
 
     private void buildAnnotationChecks(
-            @NonNull MethodSpec.Builder builder,
-            @NonNull RaveIR raveIR,
-            @NonNull MethodIR methodIR,
-            @NonNull TypeMirror typeMirror) {
-        boolean isNullable = (!methodIR.hasAnnotation(NonNull.class)
-                && raveIR.getMode().equals(Validator.Mode.DEFAULT))
-                || methodIR.hasAnnotation(Nullable.class);
-
-        boolean hasNonNullOrNullable = methodIR.hasAnnotation(NonNull.class)
-                || methodIR.hasAnnotation(Nullable.class)
-                || raveIR.getMode().equals(Validator.Mode.STRICT);
-
-        AnnotationWriter writer = new AnnotationWriter(
-                typeMirror,
-                builder,
-                MethodSpec.methodBuilder(methodIR.getMethodGetterName()).build(),
-                isNullable,
-                hasNonNullOrNullable);
-
-        if (hasNonNullOrNullable
-                && !(methodIR.hasAnnotation(Size.class) || methodIR.hasAnnotation(StringDef.class))
-                && !methodIR.isPrimative()) {
+            @NonNull MethodSpec.Builder builder, @NonNull MethodIR methodIR, @NonNull TypeMirror typeMirror) {
+        // No check needed for Nullable annotation.
+        boolean isNullable = !methodIR.hasAnnotation(NonNull.class);
+        boolean hasNonNullOrNullable = methodIR.hasAnnotation(NonNull.class) || methodIR.hasAnnotation(Nullable.class);
+        AnnotationWriter writer = new AnnotationWriter(typeMirror, builder,
+                MethodSpec.methodBuilder(methodIR.getMethodGetterName()).build(), isNullable, hasNonNullOrNullable);
+        if (hasNonNullOrNullable && !(methodIR.hasAnnotation(Size.class) || methodIR.hasAnnotation(StringDef.class))) {
             writer.writeNullable();
         }
         if (methodIR.hasAnnotation(Size.class)) {

--- a/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
+++ b/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
@@ -340,6 +340,32 @@ public class RaveProcessorTest {
                 .failsToCompile().withErrorContaining(AnnotationVerifier.INT_RANGE_BAD_RETURN_TYPE_ERROR);
     }
 
+    @Test
+    public void testStrictModeValidationStategy_whenNoAnnotationPresent_shouldTreatAsNonNull() {
+        sources.add(JavaFileObjects.forResource("fixtures/validationstrategy/simple/SimpleCase.java"));
+        sources.add(JavaFileObjects.forResource("fixtures/validationstrategy/StrictModeFactory.java"));
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects
+                        .forResource("fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java"));
+    }
+
+    @Test
+    public void testStrictModeValidationStategy_whenPrimativePresent_shouldNotValidatePrimative() {
+        sources.add(JavaFileObjects.forResource("fixtures/validationstrategy/primative/PrimativeCase.java"));
+        sources.add(JavaFileObjects.forResource("fixtures/validationstrategy/StrictModeFactory.java"));
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource(
+                        "fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java"));
+    }
+
     static String readFile(String path) throws IOException {
         byte[] encoded = Files.readAllBytes(Paths.get(path));
         return new String(encoded);

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/StrictModeFactory.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/StrictModeFactory.java
@@ -1,0 +1,17 @@
+package fixtures.validationstrategy;
+
+import android.support.annotation.NonNull;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.Validator;
+import com.uber.rave.ValidatorFactory;
+
+
+@Validator(mode = Validator.Mode.STRICT)
+public final class StrictModeFactory implements ValidatorFactory {
+    @NonNull
+    @Override
+    public BaseValidator generateValidator() {
+        return new StrictModeFactory_Generated_Validator();
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/PrimativeCase.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/PrimativeCase.java
@@ -1,0 +1,27 @@
+package fixtures.validationstrategy.primative;
+
+import fixtures.validationstrategy.StrictModeFactory;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.uber.rave.annotation.Validated;
+
+@Validated(factory = StrictModeFactory.class)
+public class PrimativeCase {
+    int primativeField;
+    int objectField;
+
+    public PrimativeCase(int field) {
+        this.primativeField = primativeField;
+        this.objectField = primativeField;
+    }
+
+    public int getPrimativeField() {
+        return primativeField;
+    }
+
+    public Object getObjectField() {
+        return objectField;
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
@@ -1,0 +1,50 @@
+package fixtures.validationstrategy;
+
+import android.support.annotation.NonNull;
+import com.uber.rave.BaseValidator;
+import com.uber.rave.ExclusionStrategy;
+import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
+import fixtures.validationstrategy.primative.PrimativeCase;
+import java.lang.Class;
+import java.lang.IllegalArgumentException;
+import java.lang.Object;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated(
+        value = "com.uber.rave.compiler.RaveProcessor",
+        comments = "https://github.com/uber-common/rave"
+)
+public final class StrictModeFactory_Generated_Validator extends BaseValidator {
+    StrictModeFactory_Generated_Validator() {
+        addSupportedClass(PrimativeCase.class);
+        registerSelf();
+    }
+
+    @Override
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz,
+            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+        if (!clazz.isInstance(object)) {
+            throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
+        }
+        if (clazz.equals(PrimativeCase.class)) {
+            validateAs((PrimativeCase) object, exclusionStrategy);
+            return;
+        }
+        throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
+    }
+
+    private void validateAs(PrimativeCase object, ExclusionStrategy exclusionStrategy) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(PrimativeCase.class);
+        List<RaveError> raveErrors = null;
+        if (!setContextAndCheckshouldIgnoreMethod(PrimativeCase.class, "getObjectField", exclusionStrategy, context)) {
+            raveErrors = mergeErrors(raveErrors, checkNullable(object.getObjectField(), false, context));
+        }
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/SimpleCase.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/SimpleCase.java
@@ -1,0 +1,38 @@
+package fixtures.validationstrategy.simple;
+
+import fixtures.validationstrategy.StrictModeFactory;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.uber.rave.annotation.Validated;
+
+@Validated(factory = StrictModeFactory.class)
+public class SimpleCase {
+    String notNullField;
+    String canBeNullField;
+    String unannotatedField;
+
+    public SimpleCase (
+            String notNullField,
+            String canBeNullField,
+            String unannotatedField) {
+        this.notNullField = notNullField;
+        this.canBeNullField = canBeNullField;
+        this.unannotatedField = unannotatedField;
+    }
+
+    @NonNull
+    public String getNotNullField() {
+        return notNullField;
+    }
+
+    @Nullable
+    public String getCanBeNullField() {
+        return canBeNullField;
+    }
+
+    public String getUnannotatedField() {
+        return unannotatedField;
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
@@ -1,0 +1,56 @@
+package fixtures.validationstrategy;
+
+import android.support.annotation.NonNull;
+import com.uber.rave.BaseValidator;
+import com.uber.rave.ExclusionStrategy;
+import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
+import fixtures.validationstrategy.simple.SimpleCase;
+import java.lang.Class;
+import java.lang.IllegalArgumentException;
+import java.lang.Object;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated(
+        value = "com.uber.rave.compiler.RaveProcessor",
+        comments = "https://github.com/uber-common/rave"
+)
+public final class StrictModeFactory_Generated_Validator extends BaseValidator {
+    StrictModeFactory_Generated_Validator() {
+        addSupportedClass(SimpleCase.class);
+        registerSelf();
+    }
+
+    @Override
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz,
+            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+        if (!clazz.isInstance(object)) {
+            throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
+        }
+        if (clazz.equals(SimpleCase.class)) {
+            validateAs((SimpleCase) object, exclusionStrategy);
+            return;
+        }
+        throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
+    }
+
+    private void validateAs(SimpleCase object, ExclusionStrategy exclusionStrategy) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
+        List<RaveError> raveErrors = null;
+        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getNotNullField", exclusionStrategy, context)) {
+            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        }
+        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getCanBeNullField", exclusionStrategy, context)) {
+            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        }
+        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getUnannotatedField", exclusionStrategy, context)) {
+            raveErrors = mergeErrors(raveErrors, checkNullable(object.getUnannotatedField(), false, context));
+        }
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+}

--- a/rave/src/main/java/com/uber/rave/Validator.java
+++ b/rave/src/main/java/com/uber/rave/Validator.java
@@ -1,0 +1,39 @@
+package com.uber.rave;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate what assumptions RAVE should make when generating validation code for a
+ * {@link ValidatorFactory}. This annotation should be applied to your validator factory.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface Validator {
+
+    /**
+     * @return indicates what kind of assumptions RAVE should make when generating validation code at compile time.
+     */
+    Mode mode() default Mode.DEFAULT;
+
+    /**
+     * Indicates different kinds of modes RAVE can run in.
+     */
+    enum Mode {
+        /**
+         * RAVE will assume if a method is not annotated its return type is {@link Nullable}.
+         */
+        DEFAULT,
+        /**
+         * RAVE will assume if a method is not annotated, its return type is {@link NonNull}.
+         */
+        STRICT
+    }
+}


### PR DESCRIPTION
Adds `@Validator` which allows consumers to specify what kind of [nullness](https://developer.android.com/studio/write/annotations.html#adding-nullness) assumptions RAVE should make. RAVE will use these assumptions when generating validation code at compile time.

`@Validator` is applied on top of a `ValidatorFactory` and offers two modes: `STRICT` and `DEFAULT`. 

In `STRICT` mode RAVE will assume unannotated methods are `@NonNull`. 

In `DEFAULT` mode RAVE will assume unannotated methods are `@Nullable`.

In the event that an `@Validator` annotation is not applied to a `ValidatorFactory` RAVE runs in `DEFAULT` mode.

Addresses #21.