### PR TITLE
Remove ExclusionStrategy API

### DIFF
--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -196,7 +196,7 @@ final class AnnotationWriter {
      */
     private void buildStatements(@NonNull String statementFormat, Object... objects) {
         builder.addStatement("$L.$L($S)", RaveWriter.VALIDATION_CONTEXT_ARG_NAME, SET_VALIDATION_ITEM_METHOD_NAME,
-                getter.name);
+                getter.name + "()");
         builder.addStatement(statementFormat, objects);
     }
 

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -53,7 +53,7 @@ final class AnnotationWriter {
     static final String CHECK_INT_RANGE_METHOD_NAME = "checkIntRange";
     static final String CHECK_FLOAT_RANGE_METHOD_NAME = "checkFloatRange";
     static final String MERGE_ERROR_METHOD_NAME = "mergeErrors";
-    static final String SHOULD_IGNORE_METHOD_NAME = "setContextAndCheckshouldIgnoreMethod";
+    static final String SET_VALIDATION_ITEM_METHOD_NAME = "setValidatedItemName";
 
     // JavaPoet formats
     private static final String LITERAL = "$L";
@@ -195,11 +195,9 @@ final class AnnotationWriter {
      * Adds the ignore if statement check to the method and then the check statement itself.
      */
     private void buildStatements(@NonNull String statementFormat, Object... objects) {
-        builder.beginControlFlow("if (!$L($T.class, $S, $L, $L))", SHOULD_IGNORE_METHOD_NAME,
-                typeMirror, getter.name, RaveWriter.EXCLUSION_STRATEGY_MAP_ARG_NAME,
-                RaveWriter.VALIDATION_CONTEXT_ARG_NAME);
+        builder.addStatement("$L.$L($S)", RaveWriter.VALIDATION_CONTEXT_ARG_NAME, SET_VALIDATION_ITEM_METHOD_NAME,
+                getter.name);
         builder.addStatement(statementFormat, objects);
-        builder.endControlFlow();
     }
 
     /**

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -290,8 +290,10 @@ public final class RaveProcessor extends AbstractProcessor {
      */
     private void error(@Nullable Element e, @NonNull String msg, Object... args) {
         if (e == null) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Behrooz fuuuuuck");
             messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args));
         } else {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Behrooz fuuuuuck2");
             messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
         }
     }

--- a/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.test1.UseOfExcluded;
@@ -24,25 +23,23 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz,
-            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(UseOfExcluded.class)) {
-            validateAs((UseOfExcluded) object, exclusionStrategy);
+            validateAs((UseOfExcluded) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(UseOfExcluded object, ExclusionStrategy exclusionStrategy) throws
-            InvalidModelException {
+    private void validateAs(UseOfExcluded object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(UseOfExcluded.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(UseOfExcluded.class, "getCanBeNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        }
+        context.setValidatedItemName("getCanBeNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/floatrange/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/floatrange/SampleFactory_Generated_Validator.java
@@ -1,8 +1,8 @@
+
 package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.floatrange.FloatRangeTestClass;
@@ -24,47 +24,39 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(FloatRangeTestClass.class)) {
-            validateAs((FloatRangeTestClass) object, exclusionStrategy);
+            validateAs((FloatRangeTestClass) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(FloatRangeTestClass object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(FloatRangeTestClass object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(FloatRangeTestClass.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble1", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble1(), -5.5D, 10.5D));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble2(), -5.0D, Double.POSITIVE_INFINITY));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble3", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble3(), Double.NEGATIVE_INFINITY, 10.0D));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble4", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble4(), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble5", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble5(), -5.5D, 10.5D));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble6", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble6(), -5.0D, Double.POSITIVE_INFINITY));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble7", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble7(), Double.NEGATIVE_INFINITY, 10.0D));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble8", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble8(), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestClass.class, "getDouble9", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble9(), 4.9E-324D, 1.7976931348623157E308D));
-        }
+        context.setValidatedItemName("getDouble1()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble1(), -5.5D, 10.5D));
+        context.setValidatedItemName("getDouble2()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble2(), -5.0D, Double.POSITIVE_INFINITY));
+        context.setValidatedItemName("getDouble3()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble3(), Double.NEGATIVE_INFINITY, 10.0D));
+        context.setValidatedItemName("getDouble4()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble4(), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+        context.setValidatedItemName("getDouble5()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble5(), -5.5D, 10.5D));
+        context.setValidatedItemName("getDouble6()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble6(), -5.0D, Double.POSITIVE_INFINITY));
+        context.setValidatedItemName("getDouble7()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble7(), Double.NEGATIVE_INFINITY, 10.0D));
+        context.setValidatedItemName("getDouble8()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble8(), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+        context.setValidatedItemName("getDouble9()");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getDouble9(), 4.9E-324D, 1.7976931348623157E308D));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/intdef/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/intdef/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.intdef.IntDefTestClass;
@@ -24,23 +23,23 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(IntDefTestClass.class)) {
-            validateAs((IntDefTestClass) object, exclusionStrategy);
+            validateAs((IntDefTestClass) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(IntDefTestClass object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(IntDefTestClass object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntDefTestClass.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(IntDefTestClass.class, "getStandard", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0L, 1L, 2L, 9223372036854775807L, -9223372036854775808L));
-        }
+        context.setValidatedItemName("getStandard()");
+        raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0L, 1L, 2L, 9223372036854775807L, -9223372036854775808L));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/intrange/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/intrange/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.intrange.IntRangeTestClass;
@@ -24,32 +23,29 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(IntRangeTestClass.class)) {
-            validateAs((IntRangeTestClass) object, exclusionStrategy);
+            validateAs((IntRangeTestClass) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(IntRangeTestClass object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(IntRangeTestClass object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntRangeTestClass.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestClass.class, "getInt1", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt1(), -5L, 10L));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestClass.class, "getInt2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt2(), -5L, 9223372036854775807L));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestClass.class, "getInt3", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt3(), -9223372036854775808L, 10L));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestClass.class, "getInt4", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt4(), -9223372036854775808L, 9223372036854775807L));
-        }
+        context.setValidatedItemName("getInt1()");
+        raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt1(), -5L, 10L));
+        context.setValidatedItemName("getInt2()");
+        raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt2(), -5L, 9223372036854775807L));
+        context.setValidatedItemName("getInt3()");
+        raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt3(), -9223372036854775808L, 10L));
+        context.setValidatedItemName("getInt4()");
+        raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getInt4(), -9223372036854775808L, 9223372036854775807L));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.maps.ModelWithMap;
@@ -24,23 +23,23 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(ModelWithMap.class)) {
-            validateAs((ModelWithMap) object, exclusionStrategy);
+            validateAs((ModelWithMap) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(ModelWithMap object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ModelWithMap object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ModelWithMap.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ModelWithMap.class, "getMap", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getMap(), true, context));
-        }
+        context.setValidatedItemName("getMap()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getMap(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/string_def/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/string_def/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.string_def.StringDefCases;
@@ -24,47 +23,39 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(StringDefCases.class)) {
-            validateAs((StringDefCases) object, exclusionStrategy);
+            validateAs((StringDefCases) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(StringDefCases object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(StringDefCases object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(StringDefCases.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullableString1", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableString1(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNullableString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableString(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullabeString2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullabeString2(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullableArray", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableArray(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullableArray2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableArray2(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNullableArray", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableArray(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullList", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullList(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNullableList", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableList(), "Matched", "Matching", "NotMatched"));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(StringDefCases.class, "getNonNullableList2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableList2(), "Matched", "Matching", "NotMatched"));
-        }
+        context.setValidatedItemName("getNonNullableString1()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableString1(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNullableString()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableString(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNonNullabeString2()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullabeString2(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNonNullableArray()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableArray(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNonNullableArray2()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableArray2(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNullableArray()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableArray(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNonNullList()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullList(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNullableList()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(true, context, object.getNullableList(), "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("getNonNullableList2()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getNonNullableList2(), "Matched", "Matching", "NotMatched"));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.test1.SimpleCase;
@@ -25,59 +24,51 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(SimpleCase.class)) {
-            validateAs((SimpleCase) object, exclusionStrategy);
+            validateAs((SimpleCase) object);
             return;
         }
         if (clazz.equals(SimpleCase.SomeInnerClass.class)) {
-            validateAs((SimpleCase.SomeInnerClass) object, exclusionStrategy);
+            validateAs((SimpleCase.SomeInnerClass) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(SimpleCase object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(SimpleCase object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getNotNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getCanBeNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getBetweenOneAndFive", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getNames", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 5L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getArrayNames", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getArrayNames(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getIsFalse", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getIsTrue", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getUberPoolState", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getUberPoolState(), "Matched", "Matching", "NotMatched"));
-        }
+        context.setValidatedItemName("getNotNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        context.setValidatedItemName("getCanBeNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        context.setValidatedItemName("getBetweenOneAndFive()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getNames()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 5L, 5L, 1L, context));
+        context.setValidatedItemName("getArrayNames()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getArrayNames(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getIsFalse()");
+        raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
+        context.setValidatedItemName("getIsTrue()");
+        raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
+        context.setValidatedItemName("getUberPoolState()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getUberPoolState(), "Matched", "Matching", "NotMatched"));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(SimpleCase.SomeInnerClass object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(SimpleCase.SomeInnerClass object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SimpleCase.SomeInnerClass.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.SomeInnerClass.class, "getString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
-        }
+        context.setValidatedItemName("getString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package com.uber.rave.compiler;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import com.uber.rave.model.AbstractAnnotated;
@@ -40,190 +39,161 @@ public final class MyFactory_Generated_Validator extends BaseValidator {
   }
 
   @Override
-  protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+  protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+          InvalidModelException {
     if (!clazz.isInstance(object)) {
       throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
     }
     if (clazz.equals(InheritFrom.class)) {
-      validateAs((InheritFrom) object, exclusionStrategy);
+      validateAs((InheritFrom) object);
       return;
     }
     if (clazz.equals(ValidateByInterface.class)) {
-      validateAs((ValidateByInterface) object, exclusionStrategy);
+      validateAs((ValidateByInterface) object);
       return;
     }
     if (clazz.equals(MultiMethodSampleModel.class)) {
-      validateAs((MultiMethodSampleModel) object, exclusionStrategy);
+      validateAs((MultiMethodSampleModel) object);
       return;
     }
     if (clazz.equals(SingleMethodSampleModel.class)) {
-      validateAs((SingleMethodSampleModel) object, exclusionStrategy);
+      validateAs((SingleMethodSampleModel) object);
       return;
     }
     if (clazz.equals(ArrayNotNull.class)) {
-      validateAs((ArrayNotNull) object, exclusionStrategy);
+      validateAs((ArrayNotNull) object);
       return;
     }
     if (clazz.equals(AbstractAnnotated.class)) {
-      validateAs((AbstractAnnotated) object, exclusionStrategy);
+      validateAs((AbstractAnnotated) object);
       return;
     }
     if (clazz.equals(IntDefModel.class)) {
-      validateAs((IntDefModel) object, exclusionStrategy);
+      validateAs((IntDefModel) object);
       return;
     }
     if (clazz.equals(IntRangeTestModel.class)) {
-      validateAs((IntRangeTestModel) object, exclusionStrategy);
+      validateAs((IntRangeTestModel) object);
       return;
     }
     if (clazz.equals(FloatRangeTestModel.class)) {
-      validateAs((FloatRangeTestModel) object, exclusionStrategy);
+      validateAs((FloatRangeTestModel) object);
       return;
     }
     throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
   }
 
-  private void validateAs(InheritFrom object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(InheritFrom object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
     List<RaveError> raveErrors = null;
-    raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(SingleMethodSampleModel.class, object, exclusionStrategy));
-    raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object, exclusionStrategy));
-    if (!setContextAndCheckshouldIgnoreMethod(InheritFrom.class, "getNonNullString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(InheritFrom.class, "toString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
-    }
+    raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(SingleMethodSampleModel.class, object));
+    raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
+    context.setValidatedItemName("getNonNullString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
+    context.setValidatedItemName("toString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(ValidateByInterface object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(ValidateByInterface object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(ValidateByInterface.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(ValidateByInterface.class, "getNonNullString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 0L, 4L, 1L, context));
-    }
+    context.setValidatedItemName("getNonNullString()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 0L, 4L, 1L, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(MultiMethodSampleModel object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(MultiMethodSampleModel object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(MultiMethodSampleModel.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNonAnnotatedObject", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonAnnotatedObject(), true, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNotNullField", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getCanBeNullField", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getBetweenOneAndFive", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNames", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getIsFalse", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getIsTrue", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "toString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
-    }
+    context.setValidatedItemName("getNonAnnotatedObject()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonAnnotatedObject(), true, context));
+    context.setValidatedItemName("getNotNullField()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+    context.setValidatedItemName("getCanBeNullField()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+    context.setValidatedItemName("getBetweenOneAndFive()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
+    context.setValidatedItemName("getNames()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
+    context.setValidatedItemName("getIsFalse()");
+    raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
+    context.setValidatedItemName("getIsTrue()");
+    raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
+    context.setValidatedItemName("toString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(SingleMethodSampleModel object, ExclusionStrategy exclusionStrategy)
-          throws InvalidModelException {
+  private void validateAs(SingleMethodSampleModel object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(SingleMethodSampleModel.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(SingleMethodSampleModel.class, "getNotNullField", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), false, 1L, 20L, 2L, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(SingleMethodSampleModel.class, "getMatchStringDef", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getMatchStringDef(), "Matched", "Matching", "AlsoMatching"));
-    }
+    context.setValidatedItemName("getNotNullField()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), false, 1L, 20L, 2L, context));
+    context.setValidatedItemName("getMatchStringDef()");
+    raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getMatchStringDef(), "Matched", "Matching", "AlsoMatching"));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(ArrayNotNull object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(ArrayNotNull object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(ArrayNotNull.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(ArrayNotNull.class, "getSingles", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getSingles(), false, 1L, 3L, 1L, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(ArrayNotNull.class, "getStringsArray", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, isSizeOk(object.getStringsArray(), false, 5L, 20L, 1L, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(ArrayNotNull.class, "toString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
-    }
+    context.setValidatedItemName("getSingles()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getSingles(), false, 1L, 3L, 1L, context));
+    context.setValidatedItemName("getStringsArray()");
+    raveErrors = mergeErrors(raveErrors, isSizeOk(object.getStringsArray(), false, 5L, 20L, 1L, context));
+    context.setValidatedItemName("toString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.toString(), true, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(AbstractAnnotated object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(AbstractAnnotated object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(AbstractAnnotated.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(AbstractAnnotated.class, "nonNullAbstractMethodString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullAbstractMethodString(), false, context));
-    }
-    if (!setContextAndCheckshouldIgnoreMethod(AbstractAnnotated.class, "nonNullString", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullString(), false, context));
-    }
+    context.setValidatedItemName("nonNullAbstractMethodString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullAbstractMethodString(), false, context));
+    context.setValidatedItemName("nonNullString()");
+    raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullString(), false, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(IntDefModel object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(IntDefModel object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(IntDefModel.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(IntDefModel.class, "getStandard", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0L, 1L, 2L));
-    }
+    context.setValidatedItemName("getStandard()");
+    raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0L, 1L, 2L));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(IntRangeTestModel object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(IntRangeTestModel object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(IntRangeTestModel.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestModel.class, "getValue", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getValue(), -15L, 1000L));
-    }
+    context.setValidatedItemName("getValue()");
+    raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getValue(), -15L, 1000L));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }
   }
 
-  private void validateAs(FloatRangeTestModel object, ExclusionStrategy exclusionStrategy) throws
-          InvalidModelException {
+  private void validateAs(FloatRangeTestModel object) throws InvalidModelException {
     BaseValidator.ValidationContext context = getValidationContext(FloatRangeTestModel.class);
     List<RaveError> raveErrors = null;
-    if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestModel.class, "getValue", exclusionStrategy, context)) {
-      raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5D, 1000.9D));
-    }
+    context.setValidatedItemName("getValue()");
+    raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5D, 1000.9D));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }

--- a/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.test3.InheritFrom;
@@ -32,101 +31,92 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(InheritFrom.class)) {
-            validateAs((InheritFrom) object, exclusionStrategy);
+            validateAs((InheritFrom) object);
             return;
         }
         if (clazz.equals(ValidateByInterface.class)) {
-            validateAs((ValidateByInterface) object, exclusionStrategy);
+            validateAs((ValidateByInterface) object);
             return;
         }
         if (clazz.equals(ValidateBySecondInterface.class)) {
-            validateAs((ValidateBySecondInterface) object, exclusionStrategy);
+            validateAs((ValidateBySecondInterface) object);
             return;
         }
         if (clazz.equals(ValidateSample.class)) {
-            validateAs((ValidateSample) object, exclusionStrategy);
+            validateAs((ValidateSample) object);
             return;
         }
         if (clazz.equals(ValidateSample2.class)) {
-            validateAs((ValidateSample2) object, exclusionStrategy);
+            validateAs((ValidateSample2) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(InheritFrom object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(InheritFrom object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
         List<RaveError> raveErrors = null;
-        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateSample2.class, object, exclusionStrategy));
-        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object, exclusionStrategy));
-        if (!setContextAndCheckshouldIgnoreMethod(InheritFrom.class, "getNonNullString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(InheritFrom.class, "getANullableString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getANullableString(), true, context));
-        }
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateSample2.class, object));
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
+        context.setValidatedItemName("getNonNullString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
+        context.setValidatedItemName("getANullableString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getANullableString(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateByInterface object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateByInterface object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateByInterface.class);
         List<RaveError> raveErrors = null;
-        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateBySecondInterface.class, object, exclusionStrategy));
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateByInterface.class, "getNonNullString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 1L, 2L, 1L, context));
-        }
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateBySecondInterface.class, object));
+        context.setValidatedItemName("getNonNullString()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 1L, 2L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateBySecondInterface object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateBySecondInterface object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateBySecondInterface.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateBySecondInterface.class, "getANullableString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getANullableString(), true, context));
-        }
+        context.setValidatedItemName("getANullableString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getANullableString(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateSample object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateSample object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateSample.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample.class, "getNotNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample.class, "getCanBeNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample.class, "getBetweenOneAndFive", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample.class, "getNames", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample.class, "getIsFalse", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
-        }
+        context.setValidatedItemName("getNotNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        context.setValidatedItemName("getCanBeNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        context.setValidatedItemName("getBetweenOneAndFive()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getNames()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getIsFalse()");
+        raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateSample2 object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateSample2 object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateSample2.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample2.class, "getNotNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), true, 1L, 5L, 1L, context));
-        }
+        context.setValidatedItemName("getNotNullField()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), true, 1L, 5L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.test4.InheritFrom;
@@ -28,52 +27,51 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(InheritFrom.class)) {
-            validateAs((InheritFrom) object, exclusionStrategy);
+            validateAs((InheritFrom) object);
             return;
         }
         if (clazz.equals(ValidateByInterface.class)) {
-            validateAs((ValidateByInterface) object, exclusionStrategy);
+            validateAs((ValidateByInterface) object);
             return;
         }
         if (clazz.equals(ValidateSample2.class)) {
-            validateAs((ValidateSample2) object, exclusionStrategy);
+            validateAs((ValidateSample2) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(InheritFrom object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(InheritFrom object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
         List<RaveError> raveErrors = null;
-        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateSample2.class, object, exclusionStrategy));
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateSample2.class, object));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateByInterface object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateByInterface object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateByInterface.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateByInterface.class, "getNonNullString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 1L, 2L, 1L, context));
-        }
+        context.setValidatedItemName("getNonNullString()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 1L, 2L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateSample2 object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ValidateSample2 object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateSample2.class);
         List<RaveError> raveErrors = null;
-        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object, exclusionStrategy));
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateSample2.class, "getNonNullString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), true, 1L, 5L, 1L, context));
-        }
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
+        context.setValidatedItemName("getNonNullString()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), true, 1L, 5L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/testSize/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/testSize/SampleFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.testSize.SimpleCase;
@@ -24,35 +23,31 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(SimpleCase.class)) {
-            validateAs((SimpleCase) object, exclusionStrategy);
+            validateAs((SimpleCase) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(SimpleCase object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(SimpleCase object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "checkDefaultSize1", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize1(), true, 10L, 10L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "checkDefaultSize2", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize2(), true, 1L, 15L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "checkDefaultSize3", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize3(), true, -9223372036854775808L, 9223372036854775807L, 2L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "checkDefaultSize4", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize4(), true, 10L, 10L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "checkDefaultSize5", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize5(), true, 1L, 20L, 5L, context));
-        }
+        context.setValidatedItemName("checkDefaultSize1()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize1(), true, 10L, 10L, 1L, context));
+        context.setValidatedItemName("checkDefaultSize2()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize2(), true, 1L, 15L, 1L, context));
+        context.setValidatedItemName("checkDefaultSize3()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize3(), true, -9223372036854775808L, 9223372036854775807L, 2L, context));
+        context.setValidatedItemName("checkDefaultSize4()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize4(), true, 10L, 10L, 1L, context));
+        context.setValidatedItemName("checkDefaultSize5()");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.checkDefaultSize5(), true, 1L, 20L, 5L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures.validationstrategy;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.validationstrategy.primative.PrimativeCase;
@@ -24,25 +23,23 @@ public final class StrictModeFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz,
-            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(PrimativeCase.class)) {
-            validateAs((PrimativeCase) object, exclusionStrategy);
+            validateAs((PrimativeCase) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(PrimativeCase object, ExclusionStrategy exclusionStrategy) throws
-            InvalidModelException {
+    private void validateAs(PrimativeCase object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(PrimativeCase.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(PrimativeCase.class, "getObjectField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getObjectField(), false, context));
-        }
+        context.setValidatedItemName("getObjectField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getObjectField(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
@@ -2,7 +2,6 @@ package fixtures.validationstrategy;
 
 import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
 import fixtures.validationstrategy.simple.SimpleCase;
@@ -24,31 +23,27 @@ public final class StrictModeFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz,
-            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+            InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(SimpleCase.class)) {
-            validateAs((SimpleCase) object, exclusionStrategy);
+            validateAs((SimpleCase) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(SimpleCase object, ExclusionStrategy exclusionStrategy) throws
-            InvalidModelException {
+    private void validateAs(SimpleCase object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getNotNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getCanBeNullField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SimpleCase.class, "getUnannotatedField", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getUnannotatedField(), false, context));
-        }
+        context.setValidatedItemName("getNotNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        context.setValidatedItemName("getCanBeNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        context.setValidatedItemName("getUnannotatedField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getUnannotatedField(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave/src/test/java/com/uber/rave/RaveUnitTest.java
+++ b/rave/src/test/java/com/uber/rave/RaveUnitTest.java
@@ -22,7 +22,6 @@ package com.uber.rave;
 
 import android.support.annotation.NonNull;
 
-import com.uber.rave.model.AbstractAnnotated;
 import com.uber.rave.model.IntDefModel;
 import com.uber.rave.model.NonAnnotated;
 import com.uber.rave.model.SingleMethodSampleModel;
@@ -46,7 +45,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class RaveUnitTest {
-    private static final ExclusionStrategy EMPTY_EXCLUSION = new ExclusionStrategy.Builder().build();
 
     @Test
     public void validateIgnore_whenUsingConstructor_shouldHaveExpectedBehavior() {
@@ -435,12 +433,12 @@ public class RaveUnitTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void validateAs_whenClazzTypeDoesntMatchObjectType_shouldFailWithException() throws RaveException {
-        Rave.getInstance().validateAs(new Object(), String.class, EMPTY_EXCLUSION);
+        Rave.getInstance().validateAs(new Object(), String.class);
     }
 
     @Test(expected = UnsupportedObjectException.class)
     public void validateAs_whenTypeIsNotSupported_shouldFailWithRaveUnsupportedException() throws RaveException {
-        Rave.getInstance().validateAs(new Object(), Object.class, EMPTY_EXCLUSION);
+        Rave.getInstance().validateAs(new Object(), Object.class);
     }
 
     @Test(expected = UnsupportedObjectException.class)
@@ -487,25 +485,6 @@ public class RaveUnitTest {
         Rave.getInstance().validate(new NonAnnotated(null));
     }
 
-    @Test
-    public void unAnnotateValidatorHandlerValidate_whenModelInvalidButIgnoreAll_shouldNotThrowInvalidModelException()
-            throws RaveException {
-        ExclusionStrategy.Builder builder = new ExclusionStrategy.Builder();
-        builder.addClass(AbstractAnnotated.class);
-        Rave.getInstance().validate(new NonAnnotated(null), builder.build());
-    }
-
-    @Test
-    public void unAnnotateValidatorHandlerValidate_whenModelInvalidButIgnore_shouldNotThrowInvalidModelException()
-            throws RaveException {
-        ExclusionStrategy.Builder builder = new ExclusionStrategy.Builder();
-        builder.addMethod(AbstractAnnotated.class, "nonNullAbstractMethodString");
-        builder.addMethod("com.uber.rave.model.SingleMethodSampleModel", "getMatchStringDef");
-        Rave.getInstance().validate(new NonAnnotated(null), builder.build());
-        Rave.getInstance().validate(new SingleMethodSampleModel("noNull", "notMatchingstringDef"),
-                builder.build());
-    }
-
     @Test(expected = UnsupportedObjectException.class)
     public void validate_whenNonSupportedClass_shouldThrowException() throws RaveException {
         Rave.getInstance().validate(Collections.emptyList());
@@ -517,7 +496,7 @@ public class RaveUnitTest {
         Rave.UnAnnotatedModelValidator handler = new Rave.UnAnnotatedModelValidator(1);
         handler.processNonAnnotatedClasses(Object.class);
         handler.processNonAnnotatedClasses(String.class);
-        handler.validateAs("", String.class, EMPTY_EXCLUSION);
+        handler.validateAs("", String.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -526,19 +505,19 @@ public class RaveUnitTest {
         Rave.UnAnnotatedModelValidator handler = new Rave.UnAnnotatedModelValidator(1);
         handler.processNonAnnotatedClasses(Object.class);
         handler.processNonAnnotatedClasses(String.class);
-        handler.validateAs(new Object(), Object.class, EMPTY_EXCLUSION);
+        handler.validateAs(new Object(), Object.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void unAnnotateValidatorHandlerValidateAs_whenNonSupportedClass_shouldThrowException() throws RaveException {
         Rave.UnAnnotatedModelValidator handler = new Rave.UnAnnotatedModelValidator(1);
-        handler.validateAs(new NonAnnotated(""), NonAnnotated.class, EMPTY_EXCLUSION);
+        handler.validateAs(new NonAnnotated(""), NonAnnotated.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void unAnnotateValidatorHandlerValidateAs_whenModelIsAnnotated_shouldThrowException() throws RaveException {
         Rave.UnAnnotatedModelValidator handler = new Rave.UnAnnotatedModelValidator(1);
-        handler.validateAs(new SingleMethodSampleModel("", ""), SingleMethodSampleModel.class, EMPTY_EXCLUSION);
+        handler.validateAs(new SingleMethodSampleModel("", ""), SingleMethodSampleModel.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -633,7 +612,7 @@ public class RaveUnitTest {
 
         @Override
         protected void validateAs(
-                @NonNull Object obj, @NonNull Class<?> clazz, @NonNull ExclusionStrategy exclusionStrategy)
+                @NonNull Object obj, @NonNull Class<?> clazz)
                 throws RaveException {
 
         }

--- a/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
+++ b/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
@@ -77,7 +77,7 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(SingleMethodSampleModel.class, object));
         raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
-        context.setValidatedItemName("getNonNullString");
+        context.setValidatedItemName("getNonNullString()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -88,7 +88,7 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateByInterface.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getNonNullString");
+        context.setValidatedItemName("getNonNullString()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 0L, 4L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -99,19 +99,19 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(MultiMethodSampleModel.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getNonAnnotatedObject");
+        context.setValidatedItemName("getNonAnnotatedObject()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonAnnotatedObject(), true, context));
         context.setValidatedItemName("getNotNullField");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-        context.setValidatedItemName("getCanBeNullField");
+        context.setValidatedItemName("getCanBeNullField()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        context.setValidatedItemName("getBetweenOneAndFive");
+        context.setValidatedItemName("getBetweenOneAndFive()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
-        context.setValidatedItemName("getNames");
+        context.setValidatedItemName("getNames()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
-        context.setValidatedItemName("getIsFalse");
+        context.setValidatedItemName("getIsFalse()");
         raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
-        context.setValidatedItemName("getIsTrue");
+        context.setValidatedItemName("getIsTrue()");
         raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -122,9 +122,9 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SingleMethodSampleModel.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getNotNullField");
+        context.setValidatedItemName("getNotNullField()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), false, 1L, 20L, 2L, context));
-        context.setValidatedItemName("getMatchStringDef");
+        context.setValidatedItemName("getMatchStringDef()");
         raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getMatchStringDef(), "Matched",
                 "Matching", "AlsoMatching"));
         if (raveErrors != null && !raveErrors.isEmpty()) {
@@ -135,9 +135,9 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
     private void validateAs(ArrayNotNull object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ArrayNotNull.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getSingles");
+        context.setValidatedItemName("getSingles()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getSingles(), false, 1L, 3L, 1L, context));
-        context.setValidatedItemName("getStringsArray");
+        context.setValidatedItemName("getStringsArray()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getStringsArray(), false, 5L, 20L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -148,9 +148,9 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(AbstractAnnotated.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("nonNullAbstractMethodString");
+        context.setValidatedItemName("nonNullAbstractMethodString()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullAbstractMethodString(), false, context));
-        context.setValidatedItemName("nonNullString");
+        context.setValidatedItemName("nonNullString()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullString(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -161,7 +161,7 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntDefModel.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getStandard");
+        context.setValidatedItemName("getStandard()");
         raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0, 1, 2));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -172,7 +172,7 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntRangeTestModel.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getValue");
+        context.setValidatedItemName("getValue()");
         raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getValue(), -15L, 1000L));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
@@ -183,7 +183,7 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(FloatRangeTestModel.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getValue");
+        context.setValidatedItemName("getValue()");
         raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5d, 1000.9d));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);

--- a/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
+++ b/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
@@ -3,7 +3,6 @@ package com.uber.rave.model;
 import android.support.annotation.NonNull;
 
 import com.uber.rave.BaseValidator;
-import com.uber.rave.ExclusionStrategy;
 import com.uber.rave.RaveError;
 import com.uber.rave.InvalidModelException;
 
@@ -27,46 +26,45 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
     @Override
     protected void validateAs(
             @NonNull Object object,
-            @NonNull Class<?> clazz,
-            @NonNull ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+            @NonNull Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(
                     object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
         if (clazz.equals(InheritFrom.class)) {
-            validateAs((InheritFrom) object, exclusionStrategy);
+            validateAs((InheritFrom) object);
             return;
         }
         if (clazz.equals(ValidateByInterface.class)) {
-            validateAs((ValidateByInterface) object, exclusionStrategy);
+            validateAs((ValidateByInterface) object);
             return;
         }
         if (clazz.equals(MultiMethodSampleModel.class)) {
-            validateAs((MultiMethodSampleModel) object, exclusionStrategy);
+            validateAs((MultiMethodSampleModel) object);
             return;
         }
         if (clazz.equals(SingleMethodSampleModel.class)) {
-            validateAs((SingleMethodSampleModel) object, exclusionStrategy);
+            validateAs((SingleMethodSampleModel) object);
             return;
         }
         if (clazz.equals(ArrayNotNull.class)) {
-            validateAs((ArrayNotNull) object, exclusionStrategy);
+            validateAs((ArrayNotNull) object);
             return;
         }
         if (clazz.equals(AbstractAnnotated.class)) {
-            validateAs((AbstractAnnotated) object, exclusionStrategy);
+            validateAs((AbstractAnnotated) object);
             return;
         }
         if (clazz.equals(IntDefModel.class)) {
-            validateAs((IntDefModel) object, exclusionStrategy);
+            validateAs((IntDefModel) object);
             return;
         }
         if (clazz.equals(IntRangeTestModel.class)) {
-            validateAs((IntRangeTestModel) object, exclusionStrategy);
+            validateAs((IntRangeTestModel) object);
             return;
         }
         if (clazz.equals(FloatRangeTestModel.class)) {
-            validateAs((FloatRangeTestModel) object, exclusionStrategy);
+            validateAs((FloatRangeTestModel) object);
             return;
         }
         throw new IllegalArgumentException(
@@ -74,151 +72,119 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
                         .getCanonicalName());
     }
 
-    private void validateAs(InheritFrom object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(InheritFrom object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
         List<RaveError> raveErrors = null;
-        raveErrors = mergeErrors(raveErrors,
-                reEvaluateAsSuperType(SingleMethodSampleModel.class, object, exclusionStrategy));
-        raveErrors = mergeErrors(raveErrors,
-                reEvaluateAsSuperType(ValidateByInterface.class, object, exclusionStrategy));
-        if (!setContextAndCheckshouldIgnoreMethod(InheritFrom.class, "getNonNullString", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
-        }
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(SingleMethodSampleModel.class, object));
+        raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
+        context.setValidatedItemName("getNonNullString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonNullString(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ValidateByInterface object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(ValidateByInterface object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ValidateByInterface.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ValidateByInterface.class, "getNonNullString", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 0L, 4L, 1L, context));
-        }
+        context.setValidatedItemName("getNonNullString");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), false, 0L, 4L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(MultiMethodSampleModel object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(MultiMethodSampleModel object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(MultiMethodSampleModel.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNonAnnotatedObject",
-                exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonAnnotatedObject(), true, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNotNullField", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getCanBeNullField", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getBetweenOneAndFive",
-                exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getNames", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getIsFalse", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(MultiMethodSampleModel.class, "getIsTrue", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
-        }
+        context.setValidatedItemName("getNonAnnotatedObject");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNonAnnotatedObject(), true, context));
+        context.setValidatedItemName("getNotNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        context.setValidatedItemName("getCanBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        context.setValidatedItemName("getBetweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getBetweenOneAndFive(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getNames");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNames(), true, 1L, 5L, 1L, context));
+        context.setValidatedItemName("getIsFalse");
+        raveErrors = mergeErrors(raveErrors, mustBeFalse(object.getIsFalse(), context));
+        context.setValidatedItemName("getIsTrue");
+        raveErrors = mergeErrors(raveErrors, mustBeTrue(object.getIsTrue(), context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(SingleMethodSampleModel object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(SingleMethodSampleModel object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(SingleMethodSampleModel.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(SingleMethodSampleModel.class, "getNotNullField", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), false, 1L, 20L, 2L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(SingleMethodSampleModel.class, "getMatchStringDef", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getMatchStringDef(), "Matched",
-                    "Matching", "AlsoMatching"));
-        }
+        context.setValidatedItemName("getNotNullField");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), false, 1L, 20L, 2L, context));
+        context.setValidatedItemName("getMatchStringDef");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getMatchStringDef(), "Matched",
+                "Matching", "AlsoMatching"));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(ArrayNotNull object, ExclusionStrategy exclusionStrategy) throws InvalidModelException {
+    private void validateAs(ArrayNotNull object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(ArrayNotNull.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(ArrayNotNull.class, "getSingles", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getSingles(), false, 1L, 3L, 1L, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(ArrayNotNull.class, "getStringsArray", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, isSizeOk(object.getStringsArray(), false, 5L, 20L, 1L, context));
-        }
+        context.setValidatedItemName("getSingles");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getSingles(), false, 1L, 3L, 1L, context));
+        context.setValidatedItemName("getStringsArray");
+        raveErrors = mergeErrors(raveErrors, isSizeOk(object.getStringsArray(), false, 5L, 20L, 1L, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(AbstractAnnotated object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(AbstractAnnotated object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(AbstractAnnotated.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(AbstractAnnotated.class, "nonNullAbstractMethodString",
-                exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullAbstractMethodString(), false, context));
-        }
-        if (!setContextAndCheckshouldIgnoreMethod(AbstractAnnotated.class, "nonNullString", exclusionStrategy,
-                context)) {
-            raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullString(), false, context));
-        }
+        context.setValidatedItemName("nonNullAbstractMethodString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullAbstractMethodString(), false, context));
+        context.setValidatedItemName("nonNullString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.nonNullString(), false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(IntDefModel object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(IntDefModel object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntDefModel.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(IntDefModel.class, "getStandard", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0, 1, 2));
-        }
+        context.setValidatedItemName("getStandard");
+        raveErrors = mergeErrors(raveErrors, checkIntDef(context, object.getStandard(), false, 0, 1, 2));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(IntRangeTestModel object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(IntRangeTestModel object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(IntRangeTestModel.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(IntRangeTestModel.class, "getValue", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getValue(), -15L, 1000L));
-        }
+        context.setValidatedItemName("getValue");
+        raveErrors = mergeErrors(raveErrors, checkIntRange(context, object.getValue(), -15L, 1000L));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
     }
 
-    private void validateAs(FloatRangeTestModel object, ExclusionStrategy exclusionStrategy) throws
+    private void validateAs(FloatRangeTestModel object) throws
             InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(FloatRangeTestModel.class);
         List<RaveError> raveErrors = null;
-        if (!setContextAndCheckshouldIgnoreMethod(FloatRangeTestModel.class, "getValue", exclusionStrategy, context)) {
-            raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5d, 1000.9d));
-        }
+        context.setValidatedItemName("getValue");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5d, 1000.9d));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }


### PR DESCRIPTION
With the new `@Excluded` API this is no longer required. Removing this results in less complicated (no more if statements) validation and less generated validation code (no code is generated if a field is `@Excluded`).