### PR TITLE
Do not generate validation code for void return types.

### DIFF
--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -52,6 +52,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
@@ -160,7 +161,8 @@ public final class RaveProcessor extends AbstractProcessor {
         boolean samePackage = classPackage.equals(CompilerUtils.packageNameOf(typesUtils.asElement(factoryTypeMirror)));
         for (ExecutableElement executableElement : methodElements) {
             if (!executableElement.getParameters().isEmpty()
-                    || executableElement.getModifiers().contains(Modifier.STATIC)) {
+                    || executableElement.getModifiers().contains(Modifier.STATIC)
+                    || executableElement.getReturnType().getKind().equals(TypeKind.VOID)) {
                 continue;
             }
             if (!executableElement.getModifiers().contains(Modifier.PUBLIC) && !samePackage) {

--- a/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
+++ b/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
@@ -391,6 +391,7 @@ public class RaveProcessorTest {
                         "fixtures/excluded/SampleFactory_Generated_Validator.java"));
     }
 
+    @Test
     public void testDefaultModeValidationStategy_whenUnannotatedMethodAndPrimativePresent_shouldValidate() {
         sources.add(JavaFileObjects.forResource("fixtures/unannotated/UnannotatedField.java"));
         sources.add(myValidator);
@@ -401,6 +402,19 @@ public class RaveProcessorTest {
                 .and()
                 .generatesSources(JavaFileObjects.forResource(
                         "fixtures/unannotated/SampleFactory_Generated_Validator.java"));
+    }
+
+    @Test
+    public void testVoidReturnMethod_shouldNotValidate() {
+        sources.add(JavaFileObjects.forResource("fixtures/voidreturn/VoidReturn.java"));
+        sources.add(myValidator);
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource(
+                        "fixtures/voidreturn/SampleFactory_Generated_Validator.java"));
     }
 
     static String readFile(String path) throws IOException {

--- a/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
-import fixtures.unannotated.UnannotatedField;
+import fixtures.voidreturn.VoidReturn;
 import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
@@ -18,7 +18,7 @@ import javax.annotation.Generated;
 )
 public final class SampleFactory_Generated_Validator extends BaseValidator {
     SampleFactory_Generated_Validator() {
-        addSupportedClass(UnannotatedField.class);
+        addSupportedClass(VoidReturn.class);
         registerSelf();
     }
 
@@ -28,18 +28,16 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }
-        if (clazz.equals(UnannotatedField.class)) {
-            validateAs((UnannotatedField) object);
+        if (clazz.equals(VoidReturn.class)) {
+            validateAs((VoidReturn) object);
             return;
         }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
-    private void validateAs(UnannotatedField object) throws InvalidModelException {
-        BaseValidator.ValidationContext context = getValidationContext(UnannotatedField.class);
+    private void validateAs(VoidReturn object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(VoidReturn.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getNullableField()");
-        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNullableField(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/voidreturn/VoidReturn.java
+++ b/rave-compiler/src/test/resources/fixtures/voidreturn/VoidReturn.java
@@ -1,0 +1,14 @@
+package fixtures.voidreturn;
+
+import fixtures.SampleFactory;
+import com.uber.rave.annotation.Validated;
+
+@Validated(factory = SampleFactory.class)
+public class VoidReturn {
+
+    private String test;
+
+    public void getIsTrue() {
+        test = "Hey Now";
+    }
+}


### PR DESCRIPTION
Discovered while bumping Uber's app onto Rave 1.0.0. Also re-enables a test case.