### PR TITLE
Remove apt and provided.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.1'
         classpath 'net.saliman:gradle-cobertura-plugin:2.2.8'
     }
 }
@@ -18,7 +17,6 @@ subprojects {
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:2.3.1'
-            classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         }
     }
 

--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'cobertura'
 apply plugin: 'checkstyle'
-apply plugin: 'nebula.provided-base'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -25,7 +24,7 @@ sourceSets {
 dependencies {
     compile project(':rave')
     compile deps.supportAnnotations
-    provided 'com.google.auto.service:auto-service:1.0-rc3'
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
 
     compile 'com.google.auto:auto-common:0.8'
     compile 'com.google.guava:guava:21.0'

--- a/rave-test/build.gradle
+++ b/rave-test/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'checkstyle'
-apply plugin: 'nebula.provided-base'
 
 def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
 def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
@@ -14,8 +13,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 configurations {
-    provided
-    compile.extendsFrom provided
+    compileOnly
+    compile.extendsFrom compileOnly
 }
 
 dependencies {

--- a/rave/build.gradle
+++ b/rave/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'cobertura'
 apply plugin: 'checkstyle'
-apply plugin: 'nebula.provided-base'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -15,8 +14,8 @@ for (File file : sdkHandler.sdkLoader.repositories) {
 }
 
 configurations {
-    provided
-    compile.extendsFrom provided
+    compileOnly
+    compile.extendsFrom compileOnly
 }
 
 dependencies {


### PR DESCRIPTION
This review removes `apt` and `provided` in favor of more recent and supported alternatives.

Android added `provided` before gradle had `compileOnly`. `compileOnly` is behaviorally the same as `provided` and should be used in place of `provided`.

`apt` comes from a third-party plugin and `annotationProcessor` is now the de-facto way to run annotations processors. Also, gradle android build tools v2.5 will not be compatible with `apt`.

