### PR TITLE
Use JSR 305 to annotate internals of RAVE.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,5 +28,6 @@ subprojects {
 ext.deps = [
         supportAnnotations: 'com.android.support:support-annotations:23.0.0',
         slf4japi: 'org.slf4j:slf4j-api:1.7.24',
+        jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
         junit4: 'junit:junit:4.10',
 ]

--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -24,7 +24,9 @@ sourceSets {
 dependencies {
     compile project(':rave')
     compile deps.supportAnnotations
+
     compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
+    compileOnly deps.jsr305
 
     compile 'com.google.auto:auto-common:0.8'
     compile 'com.google.guava:guava:21.0'

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationVerifier.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationVerifier.java
@@ -23,7 +23,6 @@ package com.uber.rave.compiler;
 import android.support.annotation.FloatRange;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
 import android.support.annotation.Size;
 
 import com.google.common.collect.ImmutableList;
@@ -57,13 +56,13 @@ class AnnotationVerifier {
     static final String FLOAT_RANGE_BAD_RETURN_TYPE_ERROR = " does not return an float or double value";
     static final String INT_RANGE_BAD_RETURN_TYPE_ERROR = " does not return an int or long value";
 
-    @NonNull protected final Messager messager;
-    @NonNull protected final Elements elements;
-    @NonNull protected final Types types;
+    protected final Messager messager;
+    protected final Elements elements;
+    protected final Types types;
 
     private TypeMirror seenFactoryTypeMirror = null;
 
-    AnnotationVerifier(@NonNull Messager messager, @NonNull Elements elements, @NonNull Types types) {
+    AnnotationVerifier(Messager messager, Elements elements, Types types) {
         this.messager = messager;
         this.types = types;
         this.elements = elements;
@@ -73,7 +72,6 @@ class AnnotationVerifier {
      * @return the {@link TypeMirror} for the {@link ValidatorFactory}that was seen during the
      * validation pass.
      */
-    @NonNull
     TypeMirror getSeenFactoryTypeMirror() {
         return seenFactoryTypeMirror;
     }
@@ -85,7 +83,7 @@ class AnnotationVerifier {
      *
      * @param type the {@link TypeElement} being validated.
      */
-    void verify(@NonNull TypeElement type) {
+    void verify(TypeElement type) {
         Validated validatedAnnotation = type.getAnnotation(Validated.class);
         if (validatedAnnotation == null) {
             abortWithError("Annotation processor for @" + Validated.class.getSimpleName()
@@ -172,7 +170,7 @@ class AnnotationVerifier {
      * @param factoryTypeMirror the {@link TypeMirror} of the {@link ValidatorFactory}.
      * @param type the {@link TypeElement} of the class that referenced the {@link ValidatorFactory}.
      */
-    private void checkFactoryClass(@NonNull TypeMirror factoryTypeMirror, @NonNull TypeElement type) {
+    private void checkFactoryClass(TypeMirror factoryTypeMirror, TypeElement type) {
         if (seenFactoryTypeMirror == null) {
             seenFactoryTypeMirror = factoryTypeMirror;
             return;
@@ -189,7 +187,7 @@ class AnnotationVerifier {
      *
      * @param typeElement the {@link TypeElement} of the model being verified.
      */
-    private void verifyAnnotationConflicts(@NonNull TypeElement typeElement) {
+    private void verifyAnnotationConflicts(TypeElement typeElement) {
         List<String> annotationList = new LinkedList<>();
         List<ExecutableElement> methodElements = new ImmutableList.Builder<ExecutableElement>()
                 .addAll(ElementFilter.methodsIn(typeElement.getEnclosedElements())).build();
@@ -217,7 +215,7 @@ class AnnotationVerifier {
      * @param msg The error message.
      * @param e The element at which the error occurred.
      */
-    private void abortWithError(@NonNull String msg, @NonNull Element e) {
+    private void abortWithError(String msg, Element e) {
         reportError(msg, e);
         throw new AbortProcessingException();
     }
@@ -228,7 +226,7 @@ class AnnotationVerifier {
      * @param msg The error message.
      * @param e The element at which the error occurred.
      */
-    private void reportError(@NonNull String msg, @NonNull Element e) {
+    private void reportError(String msg, Element e) {
         messager.printMessage(Diagnostic.Kind.ERROR, msg, e);
     }
 
@@ -238,7 +236,7 @@ class AnnotationVerifier {
      * @param type The type.
      * @return {@code true} if given type implements {@link java.lang.annotation.Annotation}, {@code false} otherwise.
      */
-    private boolean implementsAnnotation(@NonNull TypeElement type) {
+    private boolean implementsAnnotation(TypeElement type) {
         return types.isAssignable(type.asType(), getTypeMirror(Annotation.class));
     }
 
@@ -248,7 +246,7 @@ class AnnotationVerifier {
      * @param cls The class.
      * @return The {@link TypeMirror} for given class.
      */
-    private TypeMirror getTypeMirror(@NonNull Class<?> cls) {
+    private TypeMirror getTypeMirror(Class<?> cls) {
         return elements.getTypeElement(cls.getName()).asType();
     }
 
@@ -261,8 +259,8 @@ class AnnotationVerifier {
      * @param type the TypeElement which is used only for error logging.
      * @return the TypeMirror.
      */
-    @NonNull
-    private TypeMirror getTypeMirrorFromAnnotation(@NonNull Validated validated, @NonNull TypeElement type) {
+
+    private TypeMirror getTypeMirrorFromAnnotation(Validated validated, TypeElement type) {
         try {
             // This should always throw an exception
             validated.factory();

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -24,7 +24,6 @@ import android.support.annotation.FloatRange;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
@@ -36,7 +35,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.lang.model.type.TypeMirror;
+import javax.annotation.Nullable;
 
 /**
  * A helper class that understands how to write out the various supported {@link Rave} annotations.
@@ -62,27 +61,23 @@ final class AnnotationWriter {
     private static final String NAMES = "$N";
     private static final String STRING_LITERAL = "$S";
 
-    @NonNull private final TypeMirror typeMirror;
-    @NonNull private final MethodSpec.Builder builder;
-    @NonNull private final MethodSpec getter;
+    private final MethodSpec.Builder builder;
+    private final MethodSpec getter;
     private final boolean isNullable;
     private final boolean hasNonNullOrNullable;
 
     /**
-     * @param typeMirror the {@link TypeMirror} of the class being evaluated.
      * @param builder the {@link MethodSpec.Builder} that is used to generate the code.
      * @param getter the {@link MethodSpec} for the getter method being evaluated.
      * @param isNullable true if the method DOES NOT have have a {@link NonNull} annotation.
-     * @param hasNonNullOrNullable true if either {@link NonNull} or {@link Nullable} annotations are present on the
-     * method.
+     * @param hasNonNullOrNullable true if either {@link NonNull} or {@link android.support.annotation.Nullable}
+     * annotations are present on the method.
      */
     AnnotationWriter(
-            @NonNull TypeMirror typeMirror,
-            @NonNull MethodSpec.Builder builder,
-            @NonNull MethodSpec getter,
+            MethodSpec.Builder builder,
+            MethodSpec getter,
             boolean isNullable,
             boolean hasNonNullOrNullable) {
-        this.typeMirror = typeMirror;
         this.builder = builder;
         this.getter = getter;
         this.isNullable = isNullable;
@@ -185,7 +180,7 @@ final class AnnotationWriter {
         buildStatements(baseWriter.getFormattedString(), baseWriter.getArgs());
     }
 
-    private void checkAnnotationNotNull(Annotation annotation) {
+    private void checkAnnotationNotNull(@Nullable Annotation annotation) {
         if (annotation == null) {
             throw new RuntimeException("For method " + getter.name + " annotation is empty");
         }
@@ -194,7 +189,7 @@ final class AnnotationWriter {
     /**
      * Adds the ignore if statement check to the method and then the check statement itself.
      */
-    private void buildStatements(@NonNull String statementFormat, Object... objects) {
+    private void buildStatements(String statementFormat, Object... objects) {
         builder.addStatement("$L.$L($S)", RaveWriter.VALIDATION_CONTEXT_ARG_NAME, SET_VALIDATION_ITEM_METHOD_NAME,
                 getter.name + "()");
         builder.addStatement(statementFormat, objects);
@@ -206,8 +201,8 @@ final class AnnotationWriter {
      */
     private static final class BaseAnnotationWriter {
 
-        @NonNull private final StringBuilder builder = new StringBuilder();
-        @NonNull private final List<Object> args = new ArrayList<>();
+        private final StringBuilder builder = new StringBuilder();
+        private final List<Object> args = new ArrayList<>();
 
         /**
          * Use this constructor if you want to auto generate the getter function call as one of the first params. If the
@@ -219,9 +214,7 @@ final class AnnotationWriter {
          * @param contextFirst if true this will insert the {@link BaseValidator.ValidationContext}
          * parameter as the first parameter otherwise it won't be inserted at all.
          */
-        private BaseAnnotationWriter(
-                @NonNull MethodSpec getter, @NonNull String checkMethodName,
-                boolean contextFirst) {
+        private BaseAnnotationWriter(MethodSpec getter, String checkMethodName, boolean contextFirst) {
             addArg(LITERAL + " = ", RaveWriter.RAVE_ERROR_ARG_NAME, false);
             addArg(LITERAL + "(", MERGE_ERROR_METHOD_NAME, false);
             addArg(LITERAL, RaveWriter.RAVE_ERROR_ARG_NAME, false);
@@ -237,7 +230,7 @@ final class AnnotationWriter {
          * The basic constructor. This gives you the first few args for the checks.
          * @param checkMethodName the name of the checker method.
          */
-        private BaseAnnotationWriter(@NonNull String checkMethodName) {
+        private BaseAnnotationWriter(String checkMethodName) {
             addArg(LITERAL + " = ", RaveWriter.RAVE_ERROR_ARG_NAME, false);
             addArg(LITERAL + "(", MERGE_ERROR_METHOD_NAME, false);
             addArg(LITERAL, RaveWriter.RAVE_ERROR_ARG_NAME, false);
@@ -249,7 +242,7 @@ final class AnnotationWriter {
          * @param getter the {@link MethodSpec} of the getter.
          * @param format the format of the item returned from the getter.
          */
-        private void addGetterCall(@NonNull MethodSpec getter, @NonNull String format) {
+        private void addGetterCall(MethodSpec getter, String format) {
             addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, true);
             addArg(NAMES + "()", getter, false);
         }
@@ -260,7 +253,7 @@ final class AnnotationWriter {
          * @param arg this can either be an object or a null item.
          * @param addSeparatorBefore add a comma separator BEFORE this argument.
          */
-        void addArg(@NonNull String format, @Nullable Object arg, boolean addSeparatorBefore) {
+        void addArg(String format, @Nullable Object arg, boolean addSeparatorBefore) {
             if (addSeparatorBefore) {
                 builder.append(", ");
             }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave.compiler;
 
-import android.support.annotation.NonNull;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,14 +50,13 @@ final class ClassIR {
      * Adds a {@link MethodIR} to this {@link ClassIR}.
      * @param methodIRs the {@link MethodIR} to add.
      */
-    void addMethodIR(@NonNull MethodIR methodIRs) {
+    void addMethodIR(MethodIR methodIRs) {
         this.methodIRs.add(methodIRs);
     }
 
     /**
      * @return Returns a list of all the methods added to this method.
      */
-    @NonNull
     List<MethodIR> getAllMethods() {
         return methodIRs;
     }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/CompilerUtils.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/CompilerUtils.java
@@ -126,8 +126,9 @@ final class CompilerUtils {
      * @return true if the {@link TypeMirror} is found in the {@link Collection}.
      */
     static boolean typeMirrorInCollection(
-            @NonNull Collection<TypeMirror> typeCollection, @NonNull TypeMirror typeMirror,
-            @NonNull Types typesUtils) {
+            Collection<TypeMirror> typeCollection,
+            TypeMirror typeMirror,
+            Types typesUtils) {
         for (TypeMirror mirror : typeCollection) {
             if (typesUtils.isSameType(mirror, typeMirror)) {
                 return true;
@@ -140,7 +141,7 @@ final class CompilerUtils {
      * @param annotationName the annotation, by name, to check.
      * @return true if the annotation is supported false otherwise
      */
-    static boolean annotationsIsSupported(@NonNull String annotationName) {
+    static boolean annotationsIsSupported(String annotationName) {
         return sAnnotationMap.containsKey(annotationName);
     }
 
@@ -148,7 +149,7 @@ final class CompilerUtils {
      * @param annotationName the annotation (canonical name) to retrieve.
      * @return the {@link Class} of the annotation.
      */
-    static Class<? extends Annotation> getAnnotation(@NonNull String annotationName) {
+    static Class<? extends Annotation> getAnnotation(String annotationName) {
         return sAnnotationMap.get(annotationName);
     }
 
@@ -159,7 +160,7 @@ final class CompilerUtils {
      * @param a2 the second annotation to check.
      * @return true if the annotations are conflicting, false otherwise.
      */
-    static boolean areConflicting(@NonNull Class<? extends Annotation> a1, @NonNull Class<? extends Annotation> a2) {
+    static boolean areConflicting(Class<? extends Annotation> a1, Class<? extends Annotation> a2) {
         Set<Class<? extends Annotation>> set = sConflictingAnnotations.get(a1);
         return set.contains(a2);
     }
@@ -168,7 +169,7 @@ final class CompilerUtils {
      * Returns the name of the package that the given type is in. If the type is in the default
      * (unnamed) package then the name is the empty string.
      */
-    static String packageNameOf(@NonNull Element type) {
+    static String packageNameOf(Element type) {
         while (true) {
             Element enclosing = type.getEnclosingElement();
             if (enclosing instanceof PackageElement) {

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -20,26 +20,25 @@
 
 package com.uber.rave.compiler;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents the intermediate representation (IR) of a method within a particular data model class. This class holds
  * all the required information to generate a method which verifies a particular field in a data model.
  */
 final class MethodIR {
-    @NonNull private final Map<Class<? extends Annotation>, Annotation> annotations;
-    @NonNull private final String getterName;
+    private final Map<Class<? extends Annotation>, Annotation> annotations;
+    private final String getterName;
 
     /**
      * Create a new methodir object.
      * @param getterName the name of the method getter that this IR represents.
      */
-    MethodIR(@NonNull String getterName) {
+    MethodIR(String getterName) {
         annotations = new HashMap<>();
         this.getterName = getterName;
     }
@@ -48,7 +47,7 @@ final class MethodIR {
      * Adds a annotation to the method.
      * @param annotation the annotation to add.
      */
-    void addAnnotation(@NonNull Annotation annotation) {
+    void addAnnotation(Annotation annotation) {
         annotations.put(annotation.annotationType(), annotation);
     }
 
@@ -63,7 +62,6 @@ final class MethodIR {
      * Returns the method name. This is generally the getter method name for some field in the data model class.
      * @return the string representation of the name.
      */
-    @NonNull
     String getMethodGetterName() {
         return getterName;
     }
@@ -73,7 +71,7 @@ final class MethodIR {
      * @param cls the annoation {@link Class}.
      * @return true if this method was annotated with the input annotation, false otherwise.
      */
-    boolean hasAnnotation(@NonNull Class<? extends Annotation> cls) {
+    boolean hasAnnotation(Class<? extends Annotation> cls) {
         return annotations.containsKey(cls);
     }
 
@@ -84,7 +82,7 @@ final class MethodIR {
      * @return the annotation or null if the method wasn't annotated with it.
      */
     @Nullable
-    <A extends Annotation> A getAnnotation(@NonNull Class<A> cls) {
+    <A extends Annotation> A getAnnotation(Class<A> cls) {
         return (A) annotations.get(cls);
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveIR.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave.compiler;
 
-import android.support.annotation.NonNull;
-
 import com.uber.rave.Validator;
 import com.uber.rave.annotation.Validated;
 
@@ -37,10 +35,10 @@ final class RaveIR {
     /**
      * All the Elements with the {@link Validated} annotation.
      */
-    @NonNull private final List<ClassIR> classIRs = new ArrayList<>();
-    @NonNull private final String packageName;
-    @NonNull private final String simpleName;
-    @NonNull private final Validator.Mode mode;
+    private final List<ClassIR> classIRs = new ArrayList<>();
+    private final String packageName;
+    private final String simpleName;
+    private final Validator.Mode mode;
 
     /**
      * Create a new RAVE IR.
@@ -48,7 +46,7 @@ final class RaveIR {
      * @param simpleName the simple name of the class to be generated.
      * @param mode the validation mode to be applied when generating validation code.
      */
-    RaveIR(@NonNull String packageName, @NonNull String simpleName, @NonNull Validator.Mode mode) {
+    RaveIR(String packageName, String simpleName, Validator.Mode mode) {
         this.packageName = packageName;
         this.simpleName = simpleName;
         this.mode = mode;
@@ -58,14 +56,13 @@ final class RaveIR {
      * Add a new {@link ClassIR} to the IR.
      * @param classIRs the {@link ClassIR} to add.
      */
-    void addClassIR(@NonNull ClassIR classIRs) {
+    void addClassIR(ClassIR classIRs) {
         this.classIRs.add(classIRs);
     }
 
     /**
      * @return Returns the list of {@link ClassIR}s that were added to this IR.
      */
-    @NonNull
     List<ClassIR> getClassIRs() {
         return classIRs;
     }
@@ -80,7 +77,6 @@ final class RaveIR {
     /**
      * @return The string name representing the package of the to-be-generated class.
      */
-    @NonNull
     String getPackageName() {
         return packageName;
     }
@@ -88,7 +84,6 @@ final class RaveIR {
     /**
      * @return This simple name of the generated class.
      */
-    @NonNull
     String getSimpleName() {
         return simpleName;
     }
@@ -96,7 +91,6 @@ final class RaveIR {
     /**
      * @return The validation mode for this library.
      */
-    @NonNull
     Validator.Mode getMode() {
         return mode;
     }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -22,7 +22,6 @@ package com.uber.rave.compiler;
 
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 
 import com.google.auto.service.AutoService;
@@ -39,6 +38,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -137,7 +137,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @param raveIR the IR that will be filled in with required information collected during processing.
      * @param allTypes the elements annotated with the {@link Validated} annotation.
      */
-    private void process(@NonNull RaveIR raveIR, @NonNull List<TypeElement> allTypes) {
+    private void process(RaveIR raveIR, List<TypeElement> allTypes) {
         for (TypeElement typeElement : allTypes) {
             raveIR.addClassIR(extractClassInfo(typeElement, raveIR.getMode()));
         }
@@ -151,8 +151,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @param typeElement The {@link TypeElement} annotated with the {@link Validated} annotation.
      * @return the {@link ClassIR} object representing the type element.
      */
-    @NonNull
-    private ClassIR extractClassInfo(@NonNull TypeElement typeElement, @NonNull Validator.Mode mode) {
+    private ClassIR extractClassInfo(TypeElement typeElement, Validator.Mode mode) {
         ClassIR classIR = new ClassIR(typesUtils.erasure(typeElement.asType()));
         traverseInheritanceTree(typeElement, classIR);
         List<ExecutableElement> methodElements = new ImmutableList.Builder<ExecutableElement>()
@@ -193,16 +192,16 @@ public final class RaveProcessor extends AbstractProcessor {
     }
 
     private void addImplicitNullnessAnnotations(
-            @NonNull MethodIR methodIR,
-            @NonNull Validator.Mode mode,
-            @NonNull ExecutableElement executableElement) {
+            MethodIR methodIR,
+            Validator.Mode mode,
+            ExecutableElement executableElement) {
         if (methodIR.hasAnyAnnotation() || executableElement.getReturnType().getKind().isPrimitive()) {
             return;
         }
 
         switch (mode) {
             case DEFAULT:
-                methodIR.addAnnotation(() -> Nullable.class);
+                methodIR.addAnnotation(() -> android.support.annotation.Nullable.class);
                 break;
             case STRICT:
                 methodIR.addAnnotation(() -> NonNull.class);
@@ -239,7 +238,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @param typeElement the type element to check.
      * @param classIR the class IR that holds on to the inheritance information collected.
      */
-    private void traverseInheritanceTree(@NonNull TypeElement typeElement, @NonNull ClassIR classIR) {
+    private void traverseInheritanceTree(TypeElement typeElement, ClassIR classIR) {
         TypeMirror mirror = typeElement.getSuperclass();
         // Recurse on inherited parent class.
         if (!(mirror instanceof NoType)) {
@@ -267,8 +266,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @param types classes annotated with the {@link Validated} annotation.
      * @return {@link RaveIR} with initial parameters set.
      */
-    @NonNull
-    private RaveIR verify(@NonNull List<TypeElement> types) {
+    private RaveIR verify(List<TypeElement> types) {
         AnnotationVerifier verifier = new AnnotationVerifier(messager, elementUtils, typesUtils);
         for (TypeElement type : types) {
             verifier.verify(type);
@@ -290,7 +288,7 @@ public final class RaveProcessor extends AbstractProcessor {
      * @param msg the error message to show, optionally containing formatting characters.
      * @param args the arguments to the formatting characters.
      */
-    private void error(@Nullable Element e, @NonNull String msg, Object... args) {
+    private void error(@Nullable Element e, String msg, Object... args) {
         if (e == null) {
             messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args));
         } else {

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/package-info.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/package-info.java
@@ -1,0 +1,3 @@
+/** RAVE's annotation processor that generates validation code using annotation present on methods.*/
+@javax.annotation.ParametersAreNonnullByDefault
+package com.uber.rave.compiler;

--- a/rave-test/build.gradle
+++ b/rave-test/build.gradle
@@ -18,6 +18,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly deps.jsr305
     compile deps.supportAnnotations
     testCompile deps.slf4japi
 }

--- a/rave-test/src/main/java/com/uber/rave/AnnotationSpecs.java
+++ b/rave-test/src/main/java/com/uber/rave/AnnotationSpecs.java
@@ -20,6 +20,10 @@
 
 package com.uber.rave;
 
+import android.support.annotation.FloatRange;
+import android.support.annotation.IntDef;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 
@@ -155,8 +159,8 @@ public final class AnnotationSpecs {
          * Sets the {@link Nullable} annotation flag. This method sets the boolean which
          * indicates the presents of the annotation.
          *
-         * @param isNullable should be true if this annotation has the {@link Nullable} annotation and false if
-         * {@link android.support.annotation.NonNull} is set.
+         * @param isNullable should be true if this annotation has the {@link Nullable}
+         * annotation and false if {@link NonNull} is set.
          * @return this {@link Builder}
          */
         public Builder setIsNullable(boolean isNullable) {
@@ -177,7 +181,7 @@ public final class AnnotationSpecs {
         }
 
         /**
-         * Set the valid values for the int in a {@link android.support.annotation.IntDef}.
+         * Set the valid values for the int in a {@link IntDef}.
          *
          * @param values the valid values.
          * @return this {@link Builder}
@@ -189,7 +193,7 @@ public final class AnnotationSpecs {
         }
 
         /**
-         * Set the valid range for the int in a {@link android.support.annotation.IntRange}.
+         * Set the valid range for the int in a {@link IntRange}.
          *
          * @param from the lower bound of the range inclusive.
          * @param to the upper bound of the rnage inclusive.
@@ -203,7 +207,7 @@ public final class AnnotationSpecs {
         }
 
         /**
-         * Set the valid values for the doubles in a {@link android.support.annotation.FloatRange}.
+         * Set the valid values for the doubles in a {@link FloatRange}.
          *
          * @param from the lower bound of the range inclusive.
          * @param to the upper bound of the rnage inclusive.

--- a/rave-test/src/main/java/com/uber/rave/ObjectCreator.java
+++ b/rave-test/src/main/java/com/uber/rave/ObjectCreator.java
@@ -20,11 +20,11 @@
 
 package com.uber.rave;
 
-import android.support.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 /**
  * This is the base class for object creators.

--- a/rave/build.gradle
+++ b/rave/build.gradle
@@ -19,6 +19,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly deps.jsr305
     compile deps.supportAnnotations
 
     testCompile project(":rave-test")

--- a/rave/src/main/java/com/uber/rave/BaseValidator.java
+++ b/rave/src/main/java/com/uber/rave/BaseValidator.java
@@ -20,9 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -30,6 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 /**
  * This class should only be used by generated validator classes.
@@ -42,7 +41,7 @@ public abstract class BaseValidator {
         supportedClasses = new HashSet<>();
     }
 
-    final void validate(@NonNull Object object) throws RaveException {
+    final void validate(Object object) throws RaveException {
         Class<?> clazz = object.getClass();
         if (supportedClasses.contains(clazz)) {
             // This will call the object specific generated validate method.
@@ -53,7 +52,6 @@ public abstract class BaseValidator {
         }
     }
 
-    @NonNull
     protected final Set<Class<?>> getSupportedClasses() {
         return supportedClasses;
     }
@@ -67,8 +65,8 @@ public abstract class BaseValidator {
      * @throws RaveException if validation fails.
      */
     protected abstract void validateAs(
-            @NonNull Object obj,
-            @NonNull Class<?> clazz)
+            Object obj,
+            Class<?> clazz)
             throws RaveException;
 
     /**
@@ -82,8 +80,8 @@ public abstract class BaseValidator {
      */
     @Nullable
     protected final List<RaveError> reEvaluateAsSuperType(
-            @NonNull Class<?> clazz,
-            @NonNull Object obj) {
+            Class<?> clazz,
+            Object obj) {
         try {
             Rave.getInstance().validateAs(obj, clazz);
         } catch (RaveException e) {
@@ -104,7 +102,7 @@ public abstract class BaseValidator {
      *
      * @param clazz the {@link Class} to add.
      */
-    protected final void addSupportedClass(@NonNull Class<?> clazz) {
+    protected final void addSupportedClass(Class<?> clazz) {
         supportedClasses.add(clazz);
     }
 
@@ -114,13 +112,12 @@ public abstract class BaseValidator {
      * @param clazz the {@link Class} to tie to the {@link BaseValidator.ValidationContext}
      * @return the {@link BaseValidator.ValidationContext}
      */
-    @NonNull
-    protected static ValidationContext getValidationContext(@NonNull Class<?> clazz) {
+    protected static ValidationContext getValidationContext(Class<?> clazz) {
         return new ValidationContext(clazz);
     }
 
     @Nullable
-    protected static List<RaveError> mustBeFalse(boolean input, @NonNull ValidationContext validationContext) {
+    protected static List<RaveError> mustBeFalse(boolean input, ValidationContext validationContext) {
         if (input) {
             List<RaveError> list = new LinkedList<>();
             list.add(new RaveError(validationContext, RaveErrorStrings.MUST_BE_FALSE_ERROR));
@@ -142,10 +139,9 @@ public abstract class BaseValidator {
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return {@link List} of {@link RaveError}s which list the validation violations. Null otherwise.
      */
-    @NonNull
     protected static List<RaveError> isSizeOk(
             @Nullable String string, boolean isNullable, long min, long max, long multiple,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> errors = checkNullable(string, isNullable, validationContext);
         if (string == null) {
             return errors;
@@ -178,7 +174,7 @@ public abstract class BaseValidator {
             long min,
             long max,
             long multiple,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> raveErrors = checkNullable(collection, isNullable, validationContext);
         if (collection == null) {
             return raveErrors;
@@ -210,7 +206,7 @@ public abstract class BaseValidator {
     @Nullable
     protected static <T> List<RaveError> isSizeOk(
             @Nullable T[] array, boolean isNullable, long min, long max, long multiple,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> raveErrors = checkNullable(array, isNullable, validationContext);
         if (array == null) {
             return raveErrors;
@@ -244,7 +240,7 @@ public abstract class BaseValidator {
             long min,
             long max,
             long multiple,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> raveErrors = checkNullable(map, isNullable, validationContext);
         if (map == null) {
             return raveErrors;
@@ -265,11 +261,10 @@ public abstract class BaseValidator {
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return a list of of {@link RaveError}s if the object is not allowed to be null. Returns null otherwise.
      */
-    @NonNull
     protected static List<RaveError> checkNullable(
             @Nullable Object obj,
             boolean isNullable,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         if (obj == null) {
             if (isNullable) {
                 return Collections.<RaveError>emptyList();
@@ -299,11 +294,10 @@ public abstract class BaseValidator {
      * @param validationContext the context of the item in the class being validated. This is used in case of an error.
      * @return a list of of {@link RaveError}s if the object is not allowed to be null. Returns null otherwise.
      */
-    @NonNull
     protected static List<RaveError> checkNullable(
             @Nullable Collection<?> collection,
             boolean isNullable,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> errors = checkNullable((Object) collection, isNullable, validationContext);
         return collection == null ? errors : checkIterable(collection, errors);
     }
@@ -316,11 +310,10 @@ public abstract class BaseValidator {
      * @param validationContext the context of the item in the class being validated. This is used in case of an error.
      * @return a list of of {@link RaveError}s if the object is not allowed to be null. Returns null otherwise.
      */
-    @NonNull
     protected static <T> List<RaveError> checkNullable(
             @Nullable T[] array,
             boolean isNullable,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> errors = checkNullable((Object) array, isNullable, validationContext);
         if (array == null) {
             return errors;
@@ -350,11 +343,10 @@ public abstract class BaseValidator {
      * @return a list of of {@link RaveError}s if the object is not allowed to be null. Returns null otherwise. This
      * method will also RAVE validate the keys and values of the map if they are RAVE enabled.
      */
-    @NonNull
     protected static <K, V> List<RaveError> checkNullable(
             @Nullable Map<K, V> map,
             boolean isNullable,
-            @NonNull ValidationContext validationContext) {
+            ValidationContext validationContext) {
         List<RaveError> errors = checkNullable((Object) map, isNullable, validationContext);
         if (map == null) {
             return errors;
@@ -389,8 +381,7 @@ public abstract class BaseValidator {
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return null if input is true and a {@link List} otherwise.
      */
-    @NonNull
-    protected static List<RaveError> mustBeTrue(boolean input, @NonNull ValidationContext validationContext) {
+    protected static List<RaveError> mustBeTrue(boolean input, ValidationContext validationContext) {
         return input ? Collections.<RaveError>emptyList()
                 : createNewList(new RaveError(validationContext, RaveErrorStrings.MUST_BE_TRUE_ERROR));
     }
@@ -404,10 +395,9 @@ public abstract class BaseValidator {
      * @param acceptableValues list of strings to look in.
      * @return returns an error if string is not present in list. Otherwise returns an empty list.
      */
-    @NonNull
     protected static List<RaveError> checkStringDef(
-            boolean isNullable, @NonNull ValidationContext validationContext, @Nullable String value, String...
-            acceptableValues) {
+            boolean isNullable, ValidationContext validationContext, @Nullable String value,
+            String... acceptableValues) {
         List<RaveError> errors = checkNullable(value, isNullable, validationContext);
         if (value == null) {
             return errors;
@@ -431,10 +421,9 @@ public abstract class BaseValidator {
      * @param acceptableValues list acceptable values for the input list.
      * @return returns an error if string is not present in list. Otherwise returns an empty list.
      */
-    @NonNull
     protected static List<RaveError> checkStringDef(
             boolean isNullable,
-            @NonNull ValidationContext validationContext,
+            ValidationContext validationContext,
             @Nullable Collection<String> values,
             String... acceptableValues) {
         List<RaveError> errors = checkNullable(values, isNullable, validationContext);
@@ -457,10 +446,9 @@ public abstract class BaseValidator {
      * @param acceptableValues list acceptable values for the input array.
      * @return returns an error if string is not present in list. Otherwise returns an empty list.
      */
-    @NonNull
     protected static List<RaveError> checkStringDef(
             boolean isNullable,
-            @NonNull ValidationContext validationContext,
+            ValidationContext validationContext,
             @Nullable String[] values,
             String... acceptableValues) {
         List<RaveError> errors = checkNullable(values, isNullable, validationContext);
@@ -485,14 +473,13 @@ public abstract class BaseValidator {
      * @param to the upper bound of the check (inclusive)
      * @return the {@link RaveError} if the checked value is not within the bounds.
      */
-    @NonNull
     protected static List<RaveError> checkFloatRange(
-            @NonNull ValidationContext validationContext,
+            ValidationContext validationContext,
             double value,
             double from,
             double to) {
-        boolean lowerIsOk = (from == Double.NEGATIVE_INFINITY) ? true : value >= from;
-        boolean upperIsOk = (to == Double.POSITIVE_INFINITY) ? true : value <= to;
+        boolean lowerIsOk = (from == Double.NEGATIVE_INFINITY) || value >= from;
+        boolean upperIsOk = (to == Double.POSITIVE_INFINITY) || value <= to;
         if (lowerIsOk && upperIsOk) {
             return Collections.<RaveError>emptyList();
         }
@@ -509,9 +496,8 @@ public abstract class BaseValidator {
      * @param to the upper bound of the check, inclusive.
      * @return the {@link RaveError} if the checked value is not within the bounds.
      */
-    @NonNull
     protected static List<RaveError> checkIntRange(
-            @NonNull ValidationContext validationContext,
+            ValidationContext validationContext,
             long value,
             long from,
             long to) {
@@ -533,9 +519,8 @@ public abstract class BaseValidator {
      * @param acceptableValues the values that the value parameter can take on.
      * @return an error if value is not present in list of acceptable values. Otherwise returns an empty list.
      */
-    @NonNull
     protected static List<RaveError> checkIntDef(
-            @NonNull ValidationContext validationContext, long value, boolean flag,
+            ValidationContext validationContext, long value, boolean flag,
             long... acceptableValues) {
 
         for (long acceptable : acceptableValues) {
@@ -554,8 +539,7 @@ public abstract class BaseValidator {
      * @param <T> The type of each object in the {@link Iterable}.
      * @return any new errors.
      */
-    @NonNull
-    private static <T> List<RaveError> checkIterable(@NonNull Iterable<T> iterable, @Nullable List<RaveError> errors) {
+    private static <T> List<RaveError> checkIterable(Iterable<T> iterable, @Nullable List<RaveError> errors) {
         Rave rave = Rave.getInstance();
         for (T type : iterable) {
             if (type == null) {
@@ -579,7 +563,6 @@ public abstract class BaseValidator {
      * @param errors the {@link List} to add to.
      * @return a new {@link List} if the input {@link List} was null or just append to the input {@link List}.
      */
-    @NonNull
     private static List<RaveError> appendErrors(@Nullable RaveException e, @Nullable List<RaveError> errors) {
         if (errors == null) {
             errors = new LinkedList<>();
@@ -606,9 +589,9 @@ public abstract class BaseValidator {
      * @param raveErrors the {@link List} of {@link RaveError} to add to.
      * @return a new {@link List} or {@link RaveError}s
      */
-    @NonNull
     private static List<RaveError> appendError(
-            @NonNull ValidationContext validationContext, @NonNull String msg,
+            ValidationContext validationContext,
+            String msg,
             @Nullable List<RaveError> raveErrors) {
         // If the list is empty it is also immutable so we need a new one.
         if (raveErrors == null || raveErrors.isEmpty()) {
@@ -624,8 +607,7 @@ public abstract class BaseValidator {
      * @param error the {@link RaveError} to add to the list.
      * @return a newly  populated {@link List}.
      */
-    @NonNull
-    private static List<RaveError> createNewList(@NonNull RaveError error) {
+    private static List<RaveError> createNewList(RaveError error) {
         List<RaveError> errors = new LinkedList<>();
         errors.add(error);
         return errors;
@@ -641,13 +623,12 @@ public abstract class BaseValidator {
      * @param raveErrors the list of {@link RaveError}s.
      * @return a list of {@link RaveError}.
      */
-    @NonNull
     private static List<RaveError> testMultipleParameter(
             long multiple,
             int size,
-            @NonNull ValidationContext validationContext,
-            @NonNull String elementType,
-            @NonNull List<RaveError> raveErrors) {
+            ValidationContext validationContext,
+            String elementType,
+            List<RaveError> raveErrors) {
         if (multiple >= 0 && size % multiple != 0) {
             String msg = elementType + " is not a multiple of " + multiple + ", size is " + size;
             raveErrors = appendError(validationContext, msg, raveErrors);
@@ -663,10 +644,10 @@ public abstract class BaseValidator {
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return a {@link RaveError} corresponding to the non matching error.
      */
-    @NonNull
     private static List<RaveError> createStringDefError(
-            @Nullable String value, @NonNull String[] acceptableValues,
-            @NonNull ValidationContext validationContext) {
+            @Nullable String value,
+            String[] acceptableValues,
+            ValidationContext validationContext) {
 
         StringBuilder stringBuilder = new StringBuilder();
         boolean first = true;
@@ -714,19 +695,17 @@ public abstract class BaseValidator {
      */
     public static final class ValidationContext {
 
-        @NonNull private final Class<?> clazz;
-        @NonNull private String validatedItemName = "";
+        private final Class<?> clazz;
+        private String validatedItemName = "";
 
-        private ValidationContext(@NonNull Class<?> clazz) {
+        private ValidationContext(Class<?> clazz) {
             this.clazz = clazz;
         }
 
-        @NonNull
         Class<?> getClazz() {
             return clazz;
         }
 
-        @NonNull
         String getValidatedItemName() {
             return validatedItemName;
         }
@@ -735,7 +714,7 @@ public abstract class BaseValidator {
          * The the context name for this {@link ValidationContext} object.
          * @param item the string name for the current context.
          */
-        public void setValidatedItemName(@NonNull String item) {
+        public void setValidatedItemName(String item) {
             this.validatedItemName = item;
         }
     }

--- a/rave/src/main/java/com/uber/rave/Rave.java
+++ b/rave/src/main/java/com/uber/rave/Rave.java
@@ -20,9 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import com.uber.rave.annotation.Validated;
 
 import java.util.Collections;
@@ -32,6 +29,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 /**
  * <p>
@@ -65,7 +64,6 @@ public class Rave {
      *
      * @return the singleton instance of the RAVE validator.
      */
-    @NonNull
     public static synchronized Rave getInstance() {
         return SingletonHolder.getInstance();
     }
@@ -77,7 +75,7 @@ public class Rave {
      * @param object the object to be validated.
      * @throws RaveException if validation fails.
      */
-    public void validate(@NonNull Object object) throws RaveException {
+    public void validate(Object object) throws RaveException {
         Class<?> clazz = object.getClass();
         Validated validated = clazz.getAnnotation(Validated.class);
         BaseValidator validator;
@@ -103,7 +101,7 @@ public class Rave {
      * @param validator the validator to add.
      * @param supportedModels the class types this validator supports.
      */
-    synchronized void registerValidator(@NonNull BaseValidator validator, @NonNull Set<Class<?>> supportedModels) {
+    synchronized void registerValidator(BaseValidator validator, Set<Class<?>> supportedModels) {
         for (Class<?> clazz : supportedModels) {
             BaseValidator base = classValidatorMap.put(clazz, validator);
             if (base != null) {
@@ -124,9 +122,7 @@ public class Rave {
      * validation.
      * @throws RaveException thrown if the validation process fails.
      */
-    void validateAs(
-            @NonNull Object obj,
-            @NonNull Class<?> clazz) throws RaveException {
+    void validateAs(Object obj, Class<?> clazz) throws RaveException {
         if (!clazz.isInstance(obj)) {
             throw new IllegalArgumentException("Trying to validate " + obj.getClass().getCanonicalName() + " as "
                     + clazz.getCanonicalName());
@@ -145,11 +141,11 @@ public class Rave {
         base.validateAs(obj, clazz);
     }
 
-    private void registerValidatorWithClass(@NonNull BaseValidator validator, @NonNull Class<?> supportedModel) {
+    private void registerValidatorWithClass(BaseValidator validator, Class<?> supportedModel) {
         classValidatorMap.put(supportedModel, validator);
     }
 
-    private void removeEntry(@NonNull Class<?> supportedModel) {
+    private void removeEntry(Class<?> supportedModel) {
         classValidatorMap.remove(supportedModel);
     }
 
@@ -161,7 +157,7 @@ public class Rave {
      * validator.
      */
     @Nullable
-    private BaseValidator getValidatorInstance(@NonNull Class<?> classToValidate) {
+    private BaseValidator getValidatorInstance(Class<?> classToValidate) {
         Validated validated = classToValidate.getAnnotation(Validated.class);
         if (validated == null) {
             return null;
@@ -211,8 +207,8 @@ public class Rave {
 
         @Override
         protected void validateAs(
-                @NonNull Object object,
-                @NonNull Class<?> clazz) throws RaveException {
+                Object object,
+                Class<?> clazz) throws RaveException {
             if (unsupportedClassesCache.containsKey(clazz)) {
                 throw new UnsupportedObjectException(Collections.singletonList(
                         new RaveError(clazz, "", RaveErrorStrings.CLASS_NOT_SUPPORTED_ERROR)));
@@ -236,7 +232,7 @@ public class Rave {
          *
          * @param clazz the {@link Class} to process.
          */
-        void processNonAnnotatedClasses(@NonNull Class<?> clazz) {
+        void processNonAnnotatedClasses(Class<?> clazz) {
             Validated validated = clazz.getAnnotation(Validated.class);
             if (validated != null) {
                 throw new IllegalArgumentException(
@@ -258,7 +254,7 @@ public class Rave {
          * @return true if any node in the inheritance tree is annotated with the {@link Validated} annotation. False
          * otherwise.
          */
-        private boolean traverseClassHierarchy(@NonNull Class<?> original, @NonNull Class<?> classToCheck) {
+        private boolean traverseClassHierarchy(Class<?> original, Class<?> classToCheck) {
             boolean returnValue = false;
             Class<?> parentClass = classToCheck.getSuperclass();
             if (parentClass != null) {
@@ -279,7 +275,7 @@ public class Rave {
          * @return true if any node in the inheritance tree is annotated with the {@link Validated} annotation. False
          * otherwise.
          */
-        private boolean evaluateInheritance(@NonNull Class<?> original, @NonNull Class<?> classToCheck) {
+        private boolean evaluateInheritance(Class<?> original, Class<?> classToCheck) {
             Validated validated = classToCheck.getAnnotation(Validated.class);
             if (validated != null) {
                 Set<Class<?>> set = supportedClassesCache.get(original);

--- a/rave/src/main/java/com/uber/rave/RaveError.java
+++ b/rave/src/main/java/com/uber/rave/RaveError.java
@@ -20,24 +20,22 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-
 /**
  * Holds a single Rave error. This generally will be validation failure.
  */
 public final class RaveError {
 
-    @NonNull private final String errorMsg;
+    private final String errorMsg;
 
-    @NonNull private final String classElement;
-    @NonNull private final Class<?> clazz;
+    private final String classElement;
+    private final Class<?> clazz;
 
     /**
      * @param clazz the inner most {@link Class} that failed validation.
      * @param item the name of the item that failed validation such as the method name.
      * @param errorMsg the error message.
      */
-    public RaveError(@NonNull Class<?> clazz, @NonNull String item, @NonNull String errorMsg) {
+    public RaveError(Class<?> clazz, String item, String errorMsg) {
         this.clazz = clazz;
         this.errorMsg = errorMsg;
         classElement = item;
@@ -47,7 +45,7 @@ public final class RaveError {
      * @param validationContext the {@link BaseValidator.ValidationContext}.
      * @param errorMsg the error message.
      */
-    public RaveError(@NonNull BaseValidator.ValidationContext validationContext, @NonNull String errorMsg) {
+    public RaveError(BaseValidator.ValidationContext validationContext, String errorMsg) {
         this.clazz = validationContext.getClazz();
         classElement = validationContext.getValidatedItemName();
         this.errorMsg = errorMsg;
@@ -56,7 +54,6 @@ public final class RaveError {
     /**
      * @return the {@link String} error messaged for this error.
      */
-    @NonNull
     public String getErrorMsg() {
         return errorMsg;
     }
@@ -66,7 +63,6 @@ public final class RaveError {
      *
      * @return the {@link String} representation of the element in the class.
      */
-    @NonNull
     public String getClassElement() {
         return classElement;
     }
@@ -74,13 +70,11 @@ public final class RaveError {
     /**
      * @return the {@link Class} object.
      */
-    @NonNull
     public Class<?> getClazz() {
         return clazz;
     }
 
     @Override
-    @NonNull
     public String toString() {
         if (classElement.isEmpty()) {
             return clazz.getCanonicalName() + ":" + errorMsg;

--- a/rave/src/main/java/com/uber/rave/RaveException.java
+++ b/rave/src/main/java/com/uber/rave/RaveException.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -31,14 +29,14 @@ import java.util.ListIterator;
  */
 public abstract class RaveException extends Exception {
 
-    @NonNull final List<RaveError> errors;
+    final List<RaveError> errors;
 
     /**
      * Creates a Rave Exception with the input errors.
      *
      * @param errors the errors to add.
      */
-    RaveException(@NonNull List<RaveError> errors) {
+    RaveException(List<RaveError> errors) {
         super(getFirstString(errors));
         this.errors = errors;
     }
@@ -47,7 +45,6 @@ public abstract class RaveException extends Exception {
      * @return Returns the list of error messages as a single string message.
      */
     @Override
-    @NonNull
     public final String getMessage() {
         StringBuilder builder = new StringBuilder();
         ListIterator<RaveError> iterator = errors.listIterator(errors.size());
@@ -67,8 +64,7 @@ public abstract class RaveException extends Exception {
         return errors.iterator();
     }
 
-    @NonNull
-    private static String getFirstString(@NonNull List<RaveError> errors) {
+    private static String getFirstString(List<RaveError> errors) {
         return errors.isEmpty() ? "" : errors.get(0).toString();
     }
 }

--- a/rave/src/main/java/com/uber/rave/ValidationIgnore.java
+++ b/rave/src/main/java/com/uber/rave/ValidationIgnore.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,9 +27,9 @@ import java.util.Set;
  * A container that represents the class or class+method to ignore during Rave validation.
  */
 final class ValidationIgnore {
-    @NonNull private final Set<String> ignoreMethods;
+    private final Set<String> ignoreMethods;
 
-    @NonNull private final Class<?> clazz;
+    private final Class<?> clazz;
 
     private boolean ignoreClassAll = false;
 
@@ -39,7 +37,7 @@ final class ValidationIgnore {
      * Constructor for this ignore bundle.
      * @param clazz the class to ignore.
      */
-    ValidationIgnore(@NonNull Class<?> clazz) {
+    ValidationIgnore(Class<?> clazz) {
         ignoreMethods = new HashSet<>();
         this.clazz = clazz;
     }
@@ -62,7 +60,6 @@ final class ValidationIgnore {
         return ignoreClassAll;
     }
 
-    @NonNull
     Class<?> getClazz() {
         return clazz;
     }
@@ -97,7 +94,7 @@ final class ValidationIgnore {
      * @return Will return true if the method is in the list of methods to ignore OR the entire class is set to be
      * ignored.
      */
-    boolean shouldIgnoreMethod(@NonNull String methodName) {
+    boolean shouldIgnoreMethod(String methodName) {
         return ignoreClassAll || ignoreMethods.contains(methodName);
     }
 }

--- a/rave/src/main/java/com/uber/rave/ValidatorFactory.java
+++ b/rave/src/main/java/com/uber/rave/ValidatorFactory.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-
 /**
  * This class should be extended by one class in each library that uses RAVE.
  */
@@ -30,6 +28,5 @@ public interface ValidatorFactory {
     /**
      * @return should return the generated validator class.
      */
-    @NonNull
     BaseValidator generateValidator();
 }

--- a/rave/src/main/java/com/uber/rave/annotation/Validated.java
+++ b/rave/src/main/java/com/uber/rave/annotation/Validated.java
@@ -20,8 +20,6 @@
 
 package com.uber.rave.annotation;
 
-import android.support.annotation.NonNull;
-
 import com.uber.rave.BaseValidator;
 import com.uber.rave.ValidatorFactory;
 
@@ -41,5 +39,5 @@ public @interface Validated {
      * References the input class type.
      * @return the {@link Class} of the {@link ValidatorFactory}.
      */
-    @NonNull Class<? extends ValidatorFactory> factory();
+    Class<? extends ValidatorFactory> factory();
 }

--- a/rave/src/main/java/com/uber/rave/package-info.java
+++ b/rave/src/main/java/com/uber/rave/package-info.java
@@ -1,0 +1,3 @@
+/** A runtime annotation validation engine for Android and Java applications. */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.uber.rave;


### PR DESCRIPTION
Instead of annotating the internals of RAVE with Android support annotations this uses JSR 305 annotations and assumes `@NonNull` by default using the `@javax.annotation.ParametersAreNonnullByDefault` API.