### PR TITLE
Remove Support Annotations from Runtime Classpath

### DIFF
--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -23,16 +23,18 @@ sourceSets {
 
 dependencies {
     compile project(':rave')
-    compile deps.supportAnnotations
-
-    compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
-    compileOnly deps.jsr305
 
     compile 'com.google.auto:auto-common:0.8'
     compile 'com.google.guava:guava:21.0'
     compile 'com.squareup:javapoet:1.8.0'
 
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
+    compileOnly deps.jsr305
+    compileOnly deps.supportAnnotations
+
     testCompile project(":rave-test")
+    testCompile deps.jsr305
+    testCompile deps.supportAnnotations
     testCompile 'org.assertj:assertj-core:3.6.2'
     testCompile 'com.google.android:android:4.1.1.4'
     testCompile 'com.google.testing.compile:compile-testing:0.10'

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
@@ -133,16 +133,14 @@ final class RaveWriter {
      * @return a {@link MethodSpec} for the main method.
      */
     private List<MethodSpec> generateSubtypeValidationMethods(RaveIR raveIR) {
-
         MethodSpec.Builder builder = MethodSpec.methodBuilder(VALIDATE_METHOD_NAME)
                 .addException(RAVE_INVALID_MODEL_EXCEPTION_CLASS)
                 .addModifiers(Modifier.PROTECTED)
                 .returns(void.class)
                 .addAnnotation(Override.class)
-                .addParameter(ParameterSpec.builder(Object.class, VALIDATE_METHOD_ARG_NAME)
-                        .addAnnotation(NonNull.class).build())
+                .addParameter(ParameterSpec.builder(Object.class, VALIDATE_METHOD_ARG_NAME).build())
                 .addParameter(ParameterSpec.builder(CLASS_PARAMETERIZED_TYPE_NAME, VALIDATE_METHOD_CLAZZ_ARG_NAME)
-                        .addAnnotation(NonNull.class).build());
+                    .build());
         builder.beginControlFlow("if (!$L.isInstance($L))", VALIDATE_METHOD_CLAZZ_ARG_NAME, VALIDATE_METHOD_ARG_NAME);
         builder.addStatement("throw new $T($L.getClass().getCanonicalName() + $S + $L.getCanonicalName())",
                 IllegalArgumentException.class, VALIDATE_METHOD_ARG_NAME, "is not of type",

--- a/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/floatrange/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/floatrange/SampleFactory_Generated_Validator.java
@@ -1,7 +1,6 @@
 
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -24,8 +23,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/intdef/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/intdef/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/intrange/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/intrange/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/string_def/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/string_def/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -24,8 +23,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package com.uber.rave.compiler;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -39,7 +38,7 @@ public final class MyFactory_Generated_Validator extends BaseValidator {
   }
 
   @Override
-  protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
+  protected void validateAs(Object object, Class<?> clazz) throws
           InvalidModelException {
     if (!clazz.isInstance(object)) {
       throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());

--- a/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -31,8 +30,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -27,8 +26,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/testSize/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/testSize/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/unannotated/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/unannotated/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/primative/StrictModeFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures.validationstrategy;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class StrictModeFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures.validationstrategy;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class StrictModeFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
@@ -1,6 +1,5 @@
 package fixtures;
 
-import android.support.annotation.NonNull;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.InvalidModelException;
 import com.uber.rave.RaveError;
@@ -23,8 +22,7 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     }
 
     @Override
-    protected void validateAs(@NonNull Object object, @NonNull Class<?> clazz) throws
-            InvalidModelException {
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
         if (!clazz.isInstance(object)) {
             throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
         }

--- a/rave-test/build.gradle
+++ b/rave-test/build.gradle
@@ -12,14 +12,10 @@ for (File file : sdkHandler.sdkLoader.repositories) {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-configurations {
-    compileOnly
-    compile.extendsFrom compileOnly
-}
-
 dependencies {
     compileOnly deps.jsr305
-    compile deps.supportAnnotations
+    compileOnly deps.supportAnnotations
+    
     testCompile deps.slf4japi
 }
 

--- a/rave/build.gradle
+++ b/rave/build.gradle
@@ -13,18 +13,15 @@ for (File file : sdkHandler.sdkLoader.repositories) {
     }
 }
 
-configurations {
-    compileOnly
-    compile.extendsFrom compileOnly
-}
-
 dependencies {
     compileOnly deps.jsr305
-    compile deps.supportAnnotations
+    compileOnly deps.supportAnnotations
 
     testCompile project(":rave-test")
+    testCompile deps.jsr305
     testCompile deps.junit4
     testCompile deps.slf4japi
+    testCompile deps.supportAnnotations
 }
 
 cobertura {

--- a/rave/src/main/java/com/uber/rave/BaseValidator.java
+++ b/rave/src/main/java/com/uber/rave/BaseValidator.java
@@ -20,6 +20,9 @@
 
 package com.uber.rave;
 
+import android.support.annotation.IntDef;
+import android.support.annotation.Size;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -134,7 +137,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The string must be at least this long.
      * @param max The string must not exceed this length.
-     * @param multiple The multiple constraint on the {@link android.support.annotation.Size}. If less than zero it is
+     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return {@link List} of {@link RaveError}s which list the validation violations. Null otherwise.
@@ -163,7 +166,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The collection must have least this many elements in it.
      * @param max The collection can have at most this many elements in it.
-     * @param multiple The multiple constraint on the {@link android.support.annotation.Size}. If less than zero it is
+     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return {@link List} of {@link RaveError}s which list the validation violations. Null otherwise.
@@ -197,7 +200,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The Array must have least this many elements in it.
      * @param max The Array can have at most this many elements in it.
-     * @param multiple The multiple constraint on the {@link android.support.annotation.Size}. If less than zero it is
+     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @param <T> can be anytype.
@@ -226,7 +229,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min the Array must have least this many elements in it.
      * @param max the Array can have at most this many elements in it.
-     * @param multiple the multiple constraint on the {@link android.support.annotation.Size}. If less than zero it is
+     * @param multiple the multiple constraint on the {@link Size}. If less than zero it is
      * ignored.
      * @param validationContext the context of the item in the class being validated. This is used in case of an error.
      * @param <K> key type of the map and can be any type.
@@ -510,12 +513,12 @@ public abstract class BaseValidator {
 
     /**
      * Check the value of an input long to see if it matches the acceptable values. This is the check that is run for
-     * the {@link android.support.annotation.IntDef} annotation. Note the flag value for this is currently unused but
+     * the {@link IntDef} annotation. Note the flag value for this is currently unused but
      * we may add support later.
      *
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @param value The long value to check.
-     * @param flag the is the flag value from {@link android.support.annotation.IntDef} it is currently unsupported.
+     * @param flag the is the flag value from {@link IntDef} it is currently unsupported.
      * @param acceptableValues the values that the value parameter can take on.
      * @return an error if value is not present in list of acceptable values. Otherwise returns an empty list.
      */


### PR DESCRIPTION
- Make support annotations compileOnly
- Decouple compileOnly from compile
- Remove support annotations from generated sources

Now that support annotations are `compileOnly` they won't be bundled in with RAVE.