### PR TITLE
Switch to Google's maven for support library artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.2
+    - build-tools-25.0.3
     - android-25
     - extra-google-m2repository
     - extra-android-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
 install:
   - echo y | android update sdk -u -a -t tools
   - echo y | android update sdk -u -a -t platform-tools
-  - echo y | android update sdk -u -a -t build-tools-25.0.2
+  - echo y | android update sdk -u -a -t build-tools-25.0.3
   - echo y | android update sdk -u -a -t android-25
   - echo y | android update sdk -u -a -t extra-google-m2repository
   - echo y | android update sdk -u -a -t extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.3
+    - build-tools-25.0.2
     - android-25
     - extra-google-m2repository
     - extra-android-support
@@ -13,7 +13,7 @@ android:
 install:
   - echo y | android update sdk -u -a -t tools
   - echo y | android update sdk -u -a -t platform-tools
-  - echo y | android update sdk -u -a -t build-tools-25.0.3
+  - echo y | android update sdk -u -a -t build-tools-25.0.2
   - echo y | android update sdk -u -a -t android-25
   - echo y | android update sdk -u -a -t extra-google-m2repository
   - echo y | android update sdk -u -a -t extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -9,19 +9,9 @@ buildscript {
 }
 
 subprojects {
-    buildscript {
-        repositories {
-            mavenCentral()
-            jcenter()
-
-        }
-        dependencies {
-            classpath 'com.android.tools.build:gradle:2.3.1'
-        }
-    }
-
     repositories {
         jcenter()
+        maven { url 'maven.google.com' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 subprojects {
     repositories {
         jcenter()
-        maven { url 'maven.google.com' }
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -5,14 +5,6 @@ apply plugin: 'checkstyle'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
-def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
-for (File file : sdkHandler.sdkLoader.repositories) {
-    repositories.maven {
-        url = file.toURI()
-    }
-}
-
 sourceSets {
     test {
         java {

--- a/rave-test/build.gradle
+++ b/rave-test/build.gradle
@@ -1,14 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
-def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
-for (File file : sdkHandler.sdkLoader.repositories) {
-    repositories.maven {
-        url = file.toURI()
-    }
-}
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/rave/build.gradle
+++ b/rave/build.gradle
@@ -5,14 +5,6 @@ apply plugin: 'checkstyle'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
-def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
-for (File file : sdkHandler.sdkLoader.repositories) {
-    repositories.maven {
-        url = file.toURI()
-    }
-}
-
 configurations {
     compileOnly
     compile.extendsFrom compileOnly

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,18 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        Classpath 'com.android.tools.build:gradle:2.3.1'
+    }
+}
+
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.uber.rave.sample"
@@ -20,12 +30,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:multidex:1.0.1'
     compile 'javax.inject:javax.inject:1'
 
-    compile 'com.google.dagger:dagger:2.9'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.9'
+    compile 'com.google.dagger:dagger:2.10'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.10'
 
     compile 'com.squareup.retrofit2:retrofit:2.2.0'
     compile 'com.squareup.retrofit2:converter-gson:2.2.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        Classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.uber.rave.sample"


### PR DESCRIPTION
This removes our hack and no longer depends on internal APIs of the android gradle plugin. It also means RAVE is fully compatible with plain old java projects, no android required. Complements #37 nicely

This also opportunistically bumps a couple other dependency versions in the sample and build tools, as well as only uses the android gradle plugin in the actual sample app rather than all modules.