### PR TITLE
Support any nullability annotation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Android apps consume data from a variety of sources (network, disk, etc.) that y
 
 ## Installation
 #### Gradle
-To integrate RAVE into your project add the following to your dependencies in your 'build.gradle' file:
+To integrate RAVE into your project add the following to your 'build.gradle' file:
 
 ```
-// Add RAVE dependencies
+buildscript {
+    repositories {
+        maven { url 'https://maven.google.com' }
+    }
+}
+
 dependencies {
   annotationProcessor 'com.uber:rave-compiler:1.0.1'
   compile 'com.uber:rave:1.0.1'

--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompile 'com.google.testing.compile:compile-testing:0.10'
     testCompile 'org.slf4j:slf4j-api:1.7.24'
     testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
-    testCompile "org.mockito:mockito-core:2.7.12"
+    testCompile 'org.mockito:mockito-core:2.7.12'
 }
 
 cobertura {

--- a/rave-compiler/build.gradle
+++ b/rave-compiler/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     compile 'com.google.auto:auto-common:0.8'
     compile 'com.google.guava:guava:21.0'
     compile 'com.squareup:javapoet:1.8.0'
+    compile deps.supportAnnotations
 
     compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
     compileOnly deps.jsr305
-    compileOnly deps.supportAnnotations
 
     testCompile project(":rave-test")
     testCompile deps.jsr305

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationVerifier.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationVerifier.java
@@ -195,10 +195,9 @@ class AnnotationVerifier {
             annotationList.clear();
             for (AnnotationMirror mirror : elements.getAllAnnotationMirrors(executableElement)) {
                 String annotationName = mirror.getAnnotationType().toString();
-                if (CompilerUtils.annotationsIsSupported(mirror.getAnnotationType().toString())) {
+                if (CompilerUtils.isSupportedAnnotation(mirror.getAnnotationType().toString())) {
                     for (String a : annotationList) {
-                        if (CompilerUtils.areConflicting(CompilerUtils.getAnnotation(a), CompilerUtils
-                                .getAnnotation(annotationName))) {
+                        if (CompilerUtils.areConflicting(a, annotationName)) {
                             abortWithError("Annotations " + annotationName + " cannot be used with " + a, typeElement);
                         }
                     }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -174,10 +174,16 @@ public final class RaveProcessor extends AbstractProcessor {
             MethodIR methodIR = new MethodIR(executableElement.getSimpleName().toString());
             for (AnnotationMirror mirror : elementUtils.getAllAnnotationMirrors(executableElement)) {
                 String annotationName = mirror.getAnnotationType().toString();
-                if (CompilerUtils.annotationsIsSupported(mirror.getAnnotationType().toString())) {
+                if (CompilerUtils.isSupportAnnotation(mirror.getAnnotationType().toString())) {
                     Annotation annotation =
-                            executableElement.getAnnotation(CompilerUtils.getAnnotation(annotationName));
+                            executableElement.getAnnotation(CompilerUtils.getSupportAnnotation(annotationName));
                     methodIR.addAnnotation(annotation);
+                } else if (mirror.getAnnotationType().asElement()
+                        .getSimpleName().toString().toLowerCase().equals("nullable")) {
+                    methodIR.addAnnotation(() -> android.support.annotation.Nullable.class);
+                } else if (mirror.getAnnotationType().asElement()
+                        .getSimpleName().toString().toLowerCase().equals("nonnull")) {
+                    methodIR.addAnnotation(() -> android.support.annotation.NonNull.class);
                 } else {
                     Annotation annotation = extractDefTypeAnnotations(mirror.getAnnotationType().asElement());
                     if (annotation != null) {

--- a/rave-compiler/src/test/java/com/uber/rave/compiler/CompilerUtilTest.java
+++ b/rave-compiler/src/test/java/com/uber/rave/compiler/CompilerUtilTest.java
@@ -20,9 +20,6 @@
 
 package com.uber.rave.compiler;
 
-import com.uber.rave.annotation.MustBeFalse;
-import com.uber.rave.annotation.MustBeTrue;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -31,7 +28,9 @@ public class CompilerUtilTest {
 
     @Test
     public void areConflicting_whenTrueAndFalseConflict_shouldReturnTrue() {
-        assertTrue(CompilerUtils.areConflicting(MustBeFalse.class, MustBeTrue.class));
-        assertTrue(CompilerUtils.areConflicting(MustBeTrue.class, MustBeFalse.class));
+        assertTrue(CompilerUtils.areConflicting("com.uber.rave.annotation.MustBeFalse",
+            "com.uber.rave.annotation.MustBeTrue"));
+        assertTrue(CompilerUtils.areConflicting("com.uber.rave.annotation.MustBeTrue",
+            "com.uber.rave.annotation.MustBeFalse"));
     }
 }

--- a/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
+++ b/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
@@ -417,6 +417,31 @@ public class RaveProcessorTest {
                         "fixtures/voidreturn/SampleFactory_Generated_Validator.java"));
     }
 
+    @Test
+    public void testJSR305AnnotatedMethods_shouldValidate() {
+        sources.add(JavaFileObjects.forResource("fixtures/jsr305/UseOfJSR305.java"));
+        sources.add(myValidator);
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource(
+                        "fixtures/jsr305/SampleFactory_Generated_Validator.java"));
+    }
+
+    @Test
+    public void testJSR305ConflictingAnnotations_shouldFailCompile() {
+        sources.add(JavaFileObjects.forResource("fixtures/jsr305/JSR305Conflict.java"));
+        sources.add(myValidator);
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .failsToCompile()
+                .withErrorContaining("Annotations javax.annotation.Nullable cannot be used with javax.annotation"
+                + ".Nonnull");
+    }
+
     static String readFile(String path) throws IOException {
         byte[] encoded = Files.readAllBytes(Paths.get(path));
         return new String(encoded);

--- a/rave-compiler/src/test/resources/fixtures/jsr305/JSR305Conflict.java
+++ b/rave-compiler/src/test/resources/fixtures/jsr305/JSR305Conflict.java
@@ -1,0 +1,22 @@
+package fixtures.jsr305;
+
+import fixtures.SampleFactory;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.uber.rave.annotation.Validated;
+
+@Validated(factory = SampleFactory.class)
+public class JSR305Conflict {
+    String canBeNullField;
+
+    public JSR305Conflict (String canBeNullField) {
+        this.canBeNullField = canBeNullField;
+    }
+
+    @Nonnull
+    @Nullable
+    public String getCanBeNullField() {
+        return canBeNullField;
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/jsr305/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/jsr305/SampleFactory_Generated_Validator.java
@@ -1,0 +1,47 @@
+package fixtures;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
+import fixtures.jsr305.UseOfJSR305;
+import java.lang.Class;
+import java.lang.IllegalArgumentException;
+import java.lang.Object;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated(
+        value = "com.uber.rave.compiler.RaveProcessor",
+        comments = "https://github.com/uber-common/rave"
+)
+public final class SampleFactory_Generated_Validator extends BaseValidator {
+    SampleFactory_Generated_Validator() {
+        addSupportedClass(UseOfJSR305.class);
+        registerSelf();
+    }
+
+    @Override
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
+        if (!clazz.isInstance(object)) {
+            throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
+        }
+        if (clazz.equals(UseOfJSR305.class)) {
+            validateAs((UseOfJSR305) object);
+            return;
+        }
+        throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
+    }
+
+    private void validateAs(UseOfJSR305 object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(UseOfJSR305.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("getNotNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
+        context.setValidatedItemName("getCanBeNullField()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/jsr305/UseOfJSR305.java
+++ b/rave-compiler/src/test/resources/fixtures/jsr305/UseOfJSR305.java
@@ -1,26 +1,24 @@
-package fixtures.test1;
+package fixtures.jsr305;
 
 import fixtures.SampleFactory;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-import com.uber.rave.annotation.Excluded;
 import com.uber.rave.annotation.Validated;
 
 @Validated(factory = SampleFactory.class)
-public class UseOfExcluded {
+public class UseOfJSR305 {
     String notNullField;
     String canBeNullField;
 
-    public UseOfExcluded (
+    public UseOfJSR305 (
             String notNullField,
             String canBeNullField) {
         this.notNullField = notNullField;
         this.canBeNullField = canBeNullField;
     }
 
-    @Excluded
-    @NonNull
+    @Nonnull
     public String getNotNullField() {
         return notNullField;
     }

--- a/rave/build.gradle
+++ b/rave/build.gradle
@@ -7,7 +7,6 @@ targetCompatibility = 1.7
 
 dependencies {
     compileOnly deps.jsr305
-    compileOnly deps.supportAnnotations
 
     testCompile project(":rave-test")
     testCompile deps.jsr305

--- a/rave/src/main/java/com/uber/rave/BaseValidator.java
+++ b/rave/src/main/java/com/uber/rave/BaseValidator.java
@@ -20,9 +20,6 @@
 
 package com.uber.rave;
 
-import android.support.annotation.IntDef;
-import android.support.annotation.Size;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -137,7 +134,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The string must be at least this long.
      * @param max The string must not exceed this length.
-     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
+     * @param multiple The multiple constraint on the Size. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return {@link List} of {@link RaveError}s which list the validation violations. Null otherwise.
@@ -166,7 +163,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The collection must have least this many elements in it.
      * @param max The collection can have at most this many elements in it.
-     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
+     * @param multiple The multiple constraint on the Size. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @return {@link List} of {@link RaveError}s which list the validation violations. Null otherwise.
@@ -200,7 +197,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min The Array must have least this many elements in it.
      * @param max The Array can have at most this many elements in it.
-     * @param multiple The multiple constraint on the {@link Size}. If less than zero it is
+     * @param multiple The multiple constraint on the Size. If less than zero it is
      * ignored.
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @param <T> can be anytype.
@@ -229,7 +226,7 @@ public abstract class BaseValidator {
      * @param isNullable if true than null is a valid value for the input string regardless of min and max.
      * @param min the Array must have least this many elements in it.
      * @param max the Array can have at most this many elements in it.
-     * @param multiple the multiple constraint on the {@link Size}. If less than zero it is
+     * @param multiple the multiple constraint on the Size. If less than zero it is
      * ignored.
      * @param validationContext the context of the item in the class being validated. This is used in case of an error.
      * @param <K> key type of the map and can be any type.
@@ -513,12 +510,12 @@ public abstract class BaseValidator {
 
     /**
      * Check the value of an input long to see if it matches the acceptable values. This is the check that is run for
-     * the {@link IntDef} annotation. Note the flag value for this is currently unused but
+     * the IntDef annotation. Note the flag value for this is currently unused but
      * we may add support later.
      *
      * @param validationContext The context of the item in the class being validated. This is used in case of an error.
      * @param value The long value to check.
-     * @param flag the is the flag value from {@link IntDef} it is currently unsupported.
+     * @param flag the is the flag value from IntDef it is currently unsupported.
      * @param acceptableValues the values that the value parameter can take on.
      * @return an error if value is not present in list of acceptable values. Otherwise returns an empty list.
      */

--- a/rave/src/main/java/com/uber/rave/Validator.java
+++ b/rave/src/main/java/com/uber/rave/Validator.java
@@ -1,8 +1,5 @@
 package com.uber.rave;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -28,11 +25,11 @@ public @interface Validator {
      */
     enum Mode {
         /**
-         * RAVE will assume if a method is not annotated its return type is {@link Nullable}.
+         * RAVE will assume if a method is not annotated its return type is nullable.
          */
         DEFAULT,
         /**
-         * RAVE will assume if a method is not annotated, its return type is {@link NonNull}.
+         * RAVE will assume if a method is not annotated, its return type is non null.
          */
         STRICT
     }


### PR DESCRIPTION
Adds support for any style of nullability annotation (JSR-305, RxJava, etc) in a similar fashion as Dagger `@Nullable` `@Provides` methods.

Tested this by creating a sample Java project that imported RAVE and JSR-305. Models annotated with `@Nonnull` and `@Nullable` were correctly validated.

Addresses #30 