### PR TITLE
Add an api that allows users to ignore the unsupported exception.

### DIFF
--- a/rave/src/main/java/com/uber/rave/Rave.java
+++ b/rave/src/main/java/com/uber/rave/Rave.java
@@ -101,12 +101,12 @@ public class Rave {
      * @param object the object to be validated.
      * @throws InvalidModelException if validation fails.
      */
-    private void validateIgnoreUnsupported(Object object) throws InvalidModelException {
+    public void validateIgnoreUnsupported(Object object) throws InvalidModelException {
         try {
             validate(object);
         } catch (InvalidModelException e) {
             throw e;
-        } catch (RaveException e) {}
+        } catch (RaveException e) { }
     }
     /**
      * This method is used to inject new validator objects in the global RAVE validation registry.

--- a/rave/src/main/java/com/uber/rave/Rave.java
+++ b/rave/src/main/java/com/uber/rave/Rave.java
@@ -69,8 +69,7 @@ public class Rave {
     }
 
     /**
-     * Validate an object. If the object is not supported, nothing will happen. Otherwise the object will be routed to
-     * the correct sub-validator which knows how to validate it.
+     * Validate an object.
      *
      * @param object the object to be validated.
      * @throws RaveException if validation fails.
@@ -95,6 +94,20 @@ public class Rave {
         validator.validate(object);
     }
 
+    /**
+     * Validate an object. If the object is not supported, nothing will happen. Otherwise the object will be routed to
+     * the correct sub-validator which knows how to validate it.
+     *
+     * @param object the object to be validated.
+     * @throws InvalidModelException if validation fails.
+     */
+    private void validateIgnoreUnsupported(Object object) throws InvalidModelException {
+        try {
+            validate(object);
+        } catch (InvalidModelException e) {
+            throw e;
+        } catch (RaveException e) {}
+    }
     /**
      * This method is used to inject new validator objects in the global RAVE validation registry.
      *

--- a/rave/src/test/java/com/uber/rave/RaveUnitTest.java
+++ b/rave/src/test/java/com/uber/rave/RaveUnitTest.java
@@ -384,6 +384,12 @@ public class RaveUnitTest {
         Rave.getInstance().validateAs(new Object(), Object.class);
     }
 
+    @Test
+    public void validateIgnoreUnsupported_whenTypeIsNotSupported_shouldNotFailWithRaveUnsupportedException()
+            throws RaveException {
+        Rave.getInstance().validateIgnoreUnsupported(new Object());
+    }
+
     @Test(expected = UnsupportedObjectException.class)
     public void validate_whenTypeIsNotSupported_shouldFailWithRaveUnsupportedException() throws RaveException {
         Rave.getInstance().validate(new Object());
@@ -417,6 +423,12 @@ public class RaveUnitTest {
     }
 
     @Test
+    public void unAnnotateValidatorHandlerValidateAs_whenUnValidateUnsupportedClass_shouldNotThrowException()
+            throws RaveException {
+        Rave.getInstance().validateIgnoreUnsupported(new NonAnnotated.UnAnnotatedEvenWithInheritance());
+    }
+
+    @Test
     public void unAnnotateValidatorHandlerValidateAs_whenInheritenceIsUsed_shouldValidateFine() throws RaveException {
         Rave.getInstance().validate(new NonAnnotated(""));
         Rave.getInstance().validate(new NonAnnotated(""));
@@ -431,6 +443,11 @@ public class RaveUnitTest {
     @Test(expected = UnsupportedObjectException.class)
     public void validate_whenNonSupportedClass_shouldThrowException() throws RaveException {
         Rave.getInstance().validate(Collections.emptyList());
+    }
+
+    @Test
+    public void validate_whenNonSupportedClass_shouldNotThrowException() throws RaveException {
+        Rave.getInstance().validateIgnoreUnsupported(Collections.emptyList());
     }
 
     @Test(expected = UnsupportedObjectException.class)


### PR DESCRIPTION
This change provides an additional api that allows for ignoring the unsupported exception for models that are not rave enabled.

Addresses Issue #43 