### PR TITLE
Add generated code that allows for inner private/protected fields to be validated.

### DIFF
--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -62,31 +62,36 @@ final class AnnotationWriter {
     private static final String STRING_LITERAL = "$S";
 
     private final MethodSpec.Builder builder;
-    private final MethodSpec getter;
+//    private final MethodSpec getter;
     private final boolean isNullable;
     private final boolean hasNonNullOrNullable;
+    private final String elementName;
+    private final WriterType writerType;
 
     /**
      * @param builder the {@link MethodSpec.Builder} that is used to generate the code.
-     * @param getter the {@link MethodSpec} for the getter method being evaluated.
+     * @param elementName the name for the item being evaluated.
      * @param isNullable true if the method DOES NOT have have a {@link NonNull} annotation.
      * @param hasNonNullOrNullable true if either {@link NonNull} or {@link android.support.annotation.Nullable}
      * annotations are present on the method.
      */
     AnnotationWriter(
             MethodSpec.Builder builder,
-            MethodSpec getter,
+            String elementName,
             boolean isNullable,
-            boolean hasNonNullOrNullable) {
+            boolean hasNonNullOrNullable,
+            WriterType writerType) {
         this.builder = builder;
-        this.getter = getter;
         this.isNullable = isNullable;
         this.hasNonNullOrNullable = hasNonNullOrNullable;
+        this.elementName = elementName;
+        this.writerType = writerType;
     }
 
     void writeNullable() {
         // Args: value, isNullable, validationContext
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_NULL_METHOD_NAME, false);
+        BaseAnnotationWriter baseWriter =
+                new BaseAnnotationWriter(elementName, CHECK_NULL_METHOD_NAME, false, writerType);
         baseWriter.addArg(LITERAL, isNullable, true);
         baseWriter.addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, true);
         buildStatements(baseWriter.getFormattedString(), baseWriter.getArgs());
@@ -94,14 +99,16 @@ final class AnnotationWriter {
 
     void writeMustBeFalse() {
         // Args: value, validationContext
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_MUST_BE_FALSE_METHOD_NAME, false);
+        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(elementName, CHECK_MUST_BE_FALSE_METHOD_NAME,
+                false, writerType);
         baseWriter.addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, true);
         buildStatements(baseWriter.getFormattedString(), baseWriter.getArgs());
     }
 
     void writeMustBeTrue() {
         // Args: value, validationContext
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_MUST_BE_TRUE_METHOD_NAME, false);
+        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(elementName, CHECK_MUST_BE_TRUE_METHOD_NAME, false,
+                writerType);
         baseWriter.addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, true);
         buildStatements(baseWriter.getFormattedString(), baseWriter.getArgs());
     }
@@ -118,7 +125,8 @@ final class AnnotationWriter {
             max = size.max();
         }
         // Args: value, isNullable, min, max, multiple, validationContext
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_SIZE_METHOD_NAME, false);
+        BaseAnnotationWriter baseWriter =
+                new BaseAnnotationWriter(elementName, CHECK_SIZE_METHOD_NAME, false, writerType);
         baseWriter.addArg(LITERAL, isNullable, true);
         baseWriter.addArg(LITERAL_LONG, min, true);
         baseWriter.addArg(LITERAL_LONG, max, true);
@@ -135,7 +143,7 @@ final class AnnotationWriter {
         BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(CHECK_MUST_BE_STRING_DEF_VALUE);
         baseWriter.addArg(LITERAL, isStringDefNullable, false);
         baseWriter.addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, true);
-        baseWriter.addGetterCall(getter, LITERAL);
+        baseWriter.addGetterCall(elementName, LITERAL, writerType, true);
         for (String string : acceptableStrings) {
             baseWriter.addArg(STRING_LITERAL, string, true);
         }
@@ -145,7 +153,8 @@ final class AnnotationWriter {
     void write(@Nullable IntDef intDef) {
         checkAnnotationNotNull(intDef);
         // Args: validationContext, value, flag, acceptableValues
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_MUST_BE_INT_DEF_VALUE, true);
+        BaseAnnotationWriter baseWriter =
+                new BaseAnnotationWriter(elementName, CHECK_MUST_BE_INT_DEF_VALUE, true, writerType);
         baseWriter.addArg(LITERAL, intDef.flag(), true);
         long[] acceptableInts = intDef.value();
         for (long intVale : acceptableInts) {
@@ -157,7 +166,8 @@ final class AnnotationWriter {
     void write(@Nullable IntRange intRange) {
         checkAnnotationNotNull(intRange);
         // Args: validationContext, value, from, to
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_INT_RANGE_METHOD_NAME, true);
+        BaseAnnotationWriter baseWriter =
+                new BaseAnnotationWriter(elementName, CHECK_INT_RANGE_METHOD_NAME, true, writerType);
         baseWriter.addArg(LITERAL_LONG, intRange.from(), true);
         baseWriter.addArg(LITERAL_LONG, intRange.to(), true);
         buildStatements(baseWriter.getFormattedString(), baseWriter.getArgs());
@@ -166,7 +176,8 @@ final class AnnotationWriter {
     void write(@Nullable FloatRange floatRange) {
         checkAnnotationNotNull(floatRange);
         // Args: validationContext, value, from, to
-        BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(getter, CHECK_FLOAT_RANGE_METHOD_NAME, true);
+        BaseAnnotationWriter baseWriter =
+                new BaseAnnotationWriter(elementName, CHECK_FLOAT_RANGE_METHOD_NAME, true, writerType);
         if (Double.isInfinite(floatRange.from())) {
             baseWriter.addArg("Double.NEGATIVE_INFINITY", null, true);
         } else {
@@ -182,7 +193,7 @@ final class AnnotationWriter {
 
     private void checkAnnotationNotNull(@Nullable Annotation annotation) {
         if (annotation == null) {
-            throw new RuntimeException("For method " + getter.name + " annotation is empty");
+            throw new RuntimeException("For method " + elementName + " annotation is empty");
         }
     }
 
@@ -190,8 +201,9 @@ final class AnnotationWriter {
      * Adds the ignore if statement check to the method and then the check statement itself.
      */
     private void buildStatements(String statementFormat, Object... objects) {
+        String elementPostFix = writerType == WriterType.METHOD ? "()" : "";
         builder.addStatement("$L.$L($S)", RaveWriter.VALIDATION_CONTEXT_ARG_NAME, SET_VALIDATION_ITEM_METHOD_NAME,
-                getter.name + "()");
+                elementName + elementPostFix);
         builder.addStatement(statementFormat, objects);
     }
 
@@ -209,12 +221,13 @@ final class AnnotationWriter {
          * boolean parameter is set to true then the {@link BaseValidator.ValidationContext} object
          * is inserted first otherwise it is not.  This is a convenience method for the
          * {@link BaseValidator} methods that start with either the getter method or the context.
-         * @param getter the {@link MethodSpec} for the getter.
+         * @param elementName the {@link MethodSpec} for the getter.
          * @param checkMethodName the name of the checker method being called.
          * @param contextFirst if true this will insert the {@link BaseValidator.ValidationContext}
          * parameter as the first parameter otherwise it won't be inserted at all.
          */
-        private BaseAnnotationWriter(MethodSpec getter, String checkMethodName, boolean contextFirst) {
+        private BaseAnnotationWriter(String elementName, String checkMethodName, boolean contextFirst,
+                WriterType writerType) {
             addArg(LITERAL + " = ", RaveWriter.RAVE_ERROR_ARG_NAME, false);
             addArg(LITERAL + "(", MERGE_ERROR_METHOD_NAME, false);
             addArg(LITERAL, RaveWriter.RAVE_ERROR_ARG_NAME, false);
@@ -222,8 +235,7 @@ final class AnnotationWriter {
             if (contextFirst) {
                 addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, false);
             }
-            addArg(LITERAL + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, contextFirst);
-            addArg(NAMES + "()", getter, false);
+            addGetterCall(elementName, LITERAL, writerType, contextFirst);
         }
 
         /**
@@ -239,12 +251,16 @@ final class AnnotationWriter {
 
         /**
          * Add the getter arg to the string format.
-         * @param getter the {@link MethodSpec} of the getter.
+         * @param elementName the name of the item to by written.
          * @param format the format of the item returned from the getter.
          */
-        private void addGetterCall(MethodSpec getter, String format) {
-            addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, true);
-            addArg(NAMES + "()", getter, false);
+        private void addGetterCall(String elementName, String format, WriterType writerType, boolean contextFirst) {
+            if (writerType == WriterType.METHOD) {
+                addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, contextFirst);
+                addArg(format + "()", elementName, false);
+            } else if (writerType == WriterType.FIELD) {
+                addArg(format, elementName, false);
+            }
         }
 
         /**
@@ -277,5 +293,13 @@ final class AnnotationWriter {
         Object[] getArgs() {
             return args.toArray(new Object[args.size()]);
         }
+    }
+
+    /**
+     * The enum for the different write type this writter can represent.
+     */
+    enum WriterType {
+        METHOD,
+        FIELD
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -254,12 +254,12 @@ final class AnnotationWriter {
          * @param elementName the name of the item to by written.
          * @param format the format of the item returned from the getter.
          */
-        private void addGetterCall(String elementName, String format, WriterType writerType, boolean contextFirst) {
+        private void addGetterCall(String elementName, String format, WriterType writerType, boolean prependComma) {
             if (writerType == WriterType.METHOD) {
-                addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, contextFirst);
+                addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, prependComma);
                 addArg(format + "()", elementName, false);
             } else if (writerType == WriterType.FIELD) {
-                addArg(format, elementName, false);
+                addArg(format, elementName, prependComma);
             }
         }
 

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -23,7 +23,6 @@ package com.uber.rave.compiler;
 import android.support.annotation.FloatRange;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
@@ -62,7 +61,6 @@ final class AnnotationWriter {
     private static final String STRING_LITERAL = "$S";
 
     private final MethodSpec.Builder builder;
-//    private final MethodSpec getter;
     private final boolean isNullable;
     private final boolean hasNonNullOrNullable;
     private final String elementName;
@@ -71,9 +69,9 @@ final class AnnotationWriter {
     /**
      * @param builder the {@link MethodSpec.Builder} that is used to generate the code.
      * @param elementName the name for the item being evaluated.
-     * @param isNullable true if the method DOES NOT have have a {@link NonNull} annotation.
-     * @param hasNonNullOrNullable true if either {@link NonNull} or {@link android.support.annotation.Nullable}
-     * annotations are present on the method.
+     * @param isNullable true if the element DOES NOT have have a NonNull annotation.
+     * @param hasNonNullOrNullable true if either NonNull or Nullable annotations are present on the element.
+     * @param writeType the type of write this writer is addressing (method or field).
      */
     AnnotationWriter(
             MethodSpec.Builder builder,
@@ -143,7 +141,7 @@ final class AnnotationWriter {
         BaseAnnotationWriter baseWriter = new BaseAnnotationWriter(CHECK_MUST_BE_STRING_DEF_VALUE);
         baseWriter.addArg(LITERAL, isStringDefNullable, false);
         baseWriter.addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, true);
-        baseWriter.addGetterCall(elementName, LITERAL, writeType, true);
+        baseWriter.addElementReference(elementName, LITERAL, writeType, true);
         for (String string : acceptableStrings) {
             baseWriter.addArg(STRING_LITERAL, string, true);
         }
@@ -235,7 +233,7 @@ final class AnnotationWriter {
             if (contextFirst) {
                 addArg(LITERAL, RaveWriter.VALIDATION_CONTEXT_ARG_NAME, false);
             }
-            addGetterCall(elementName, LITERAL, writeType, contextFirst);
+            addElementReference(elementName, LITERAL, writeType, contextFirst);
         }
 
         /**
@@ -254,7 +252,7 @@ final class AnnotationWriter {
          * @param elementName the name of the item to by written.
          * @param format the format of the item returned from the getter.
          */
-        private void addGetterCall(String elementName, String format, WriteType writeType, boolean prependComma) {
+        private void addElementReference(String elementName, String format, WriteType writeType, boolean prependComma) {
             if (writeType == WriteType.METHOD) {
                 addArg(format + ".", RaveWriter.VALIDATE_METHOD_ARG_NAME, prependComma);
                 addArg(format + "()", elementName, false);

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/AnnotationWriter.java
@@ -187,7 +187,7 @@ final class AnnotationWriter {
 
     private void checkAnnotationNotNull(@Nullable Annotation annotation) {
         if (annotation == null) {
-            throw new RuntimeException("For " + elementInfo.errorString() + " annotation is empty");
+            throw new RuntimeException("For " + elementInfo.typeInfoString() + " annotation is empty");
         }
     }
 
@@ -299,12 +299,18 @@ final class AnnotationWriter {
             this.writeType = writeType;
         }
 
+        /**
+         * @return the string format when outputting this element.
+         */
         String formatString() {
             String elementPostFix = writeType == WriteType.METHOD ? "()" : "";
             return elementName + elementPostFix;
         }
 
-        public String errorString() {
+        /**
+         * @return the a string which describes the info for this element.
+         */
+        String typeInfoString() {
             return writeType + " " + elementName;
         }
     }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
@@ -32,8 +32,9 @@ import javax.lang.model.util.Types;
  */
 final class ClassIR {
 
-    private final List<MethodIR> methodIRs;
-    private final List<TypeMirror> inheritedTypes;
+    private final List<MethodIR> methodIRs = new ArrayList<>();
+    private final List<FieldIR> fieldIRs = new ArrayList<>();
+    private final List<TypeMirror> inheritedTypes = new ArrayList<>();
     private final TypeMirror typeMirror;
 
     /**
@@ -41,8 +42,6 @@ final class ClassIR {
      * @param typeMirror the type mirror of the class this ir represents.
      */
     ClassIR(TypeMirror typeMirror) {
-        methodIRs = new ArrayList<>();
-        inheritedTypes = new ArrayList<>();
         this.typeMirror = typeMirror;
     }
 
@@ -84,5 +83,26 @@ final class ClassIR {
      */
     List<TypeMirror> getInheritedTypes() {
         return inheritedTypes;
+    }
+
+    /**
+     *  Adds a {@link FieldIR} to this {@link ClassIR}.
+     * @param fieldIR the {@link FieldIR} to add.
+     */
+    void addFieldIR(FieldIR fieldIR) {
+        fieldIRs.add(fieldIR);
+    }
+
+    List<FieldIR> getFieldIRs() {
+        return fieldIRs;
+    }
+
+    public boolean hasValidatableFields() {
+        for (FieldIR fieldIR : fieldIRs) {
+            if (fieldIR.hasAnyAnnotation()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
@@ -20,7 +20,11 @@
 
 package com.uber.rave.compiler;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.lang.model.type.TypeMirror;
@@ -32,8 +36,8 @@ import javax.lang.model.util.Types;
  */
 final class ClassIR {
 
-    private final List<MethodIR> methodIRs = new ArrayList<>();
-    private final List<FieldIR> fieldIRs = new ArrayList<>();
+    private final List<MethodIR> methodIRs = new LinkedList<>();
+    private final List<FieldIR> fieldIRs = new LinkedList<>();
     private final List<TypeMirror> inheritedTypes = new ArrayList<>();
     private final TypeMirror typeMirror;
 
@@ -57,7 +61,7 @@ final class ClassIR {
      * @return Returns a list of all the methods added to this method.
      */
     List<MethodIR> getAllMethods() {
-        return methodIRs;
+        return new ImmutableList.Builder<MethodIR>().addAll(methodIRs).build();
     }
 
     /**
@@ -97,18 +101,15 @@ final class ClassIR {
      * @return Returns a list of all the field added to this method IR.
      */
     List<FieldIR> getAllFieldIRs() {
-        return fieldIRs;
+        return new ImmutableList.Builder<FieldIR>().addAll(fieldIRs).build();
     }
 
     /**
      * @return true if any field has an annotation, false otherwise.
      */
     public boolean hasValidatableFields() {
-        for (FieldIR fieldIR : fieldIRs) {
-            if (fieldIR.hasAnyAnnotation()) {
-                return true;
-            }
-        }
-        return false;
+        return fieldIRs.stream()
+                .anyMatch((Predicate<FieldIR>) fieldIR -> fieldIR != null ? fieldIR.hasAnyAnnotation() : false);
+
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ClassIR.java
@@ -93,10 +93,16 @@ final class ClassIR {
         fieldIRs.add(fieldIR);
     }
 
-    List<FieldIR> getFieldIRs() {
+    /**
+     * @return Returns a list of all the field added to this method IR.
+     */
+    List<FieldIR> getAllFieldIRs() {
         return fieldIRs;
     }
 
+    /**
+     * @return true if any field has an annotation, false otherwise.
+     */
     public boolean hasValidatableFields() {
         for (FieldIR fieldIR : fieldIRs) {
             if (fieldIR.hasAnyAnnotation()) {

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * Created by beh on 6/9/17.
+ * This is the IR base class that is shared by the {@link MethodIR} and {@link FieldIR}
  */
 abstract class ElementIRBase {
     private final String name;

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * This is the IR base class that is shared by the {@link MethodIR} and {@link FieldIR}
+ * This is the IR base class that is shared by the {@link MethodIR} and {@link FieldIR}.
  */
 abstract class ElementIRBase {
     private final String name;

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/ElementIRBase.java
@@ -1,0 +1,66 @@
+package com.uber.rave.compiler;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * Created by beh on 6/9/17.
+ */
+abstract class ElementIRBase {
+    private final String name;
+    private final Map<Class<? extends Annotation>, Annotation> annotations;
+    /**
+     * Create a new element IR object.
+     * @param name the name of the element getter that this IR represents.
+     */
+    ElementIRBase(String name) {
+        annotations = new HashMap<>();
+        this.name = name;
+    }
+
+    /**
+     * Adds a annotation to the element.
+     * @param annotation the annotation to add.
+     */
+    void addAnnotation(Annotation annotation) {
+        annotations.put(annotation.annotationType(), annotation);
+    }
+
+    /**
+     * @return whether the annotations map has any of the RAVE supported annotations.
+     */
+    boolean hasAnyAnnotation() {
+        return annotations.size() > 0;
+    }
+
+    /**
+     * Returns the element name. This is generally the getter element name for some field in the data model class.
+     * @return the string representation of the name.
+     */
+    String getElementName() {
+        return name;
+    }
+
+    /**
+     * A quick lookup to see if this element was annotated with a particular annotation.
+     * @param cls the annoation {@link Class}.
+     * @return true if this element was annotated with the input annotation, false otherwise.
+     */
+    boolean hasAnnotation(Class<? extends Annotation> cls) {
+        return annotations.containsKey(cls);
+    }
+
+    /**
+     * Returns the actual annotation. Null if the element doesn't have that particular annotation.
+     * @param cls the annotation {@link Class}.
+     * @param <A> the generic must extend {@link Annotation}.
+     * @return the annotation or null if the element wasn't annotated with it.
+     */
+    @Nullable
+    <A extends Annotation> A getAnnotation(Class<A> cls) {
+        return (A) annotations.get(cls);
+    }
+}

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
@@ -1,0 +1,28 @@
+package com.uber.rave.compiler;
+
+import com.squareup.javapoet.TypeName;
+
+/**
+ * Todo Behrooz.
+ */
+public class FieldIR extends ElementIRBase {
+
+    private final TypeName typeName;
+
+    /**
+     * Create a new field IR object.
+     * @param fieldName the name of the field that this IR represents.
+     * @param typeName
+     */
+    FieldIR(String fieldName, TypeName typeName) {
+        super(fieldName);
+        this.typeName = typeName;
+    }
+
+    /**
+     * @return get the {@link TypeName} for this field.
+     */
+    public TypeName getTypeName() {
+        return typeName;
+    }
+}

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
@@ -6,7 +6,7 @@ import com.squareup.javapoet.TypeName;
  * Represents the intermediate representation (IR) of a field within a particular data model class. This class holds
  * all the required information to generate a method which verifies the inner fields in a data model.
  */
-public class FieldIR extends ElementIRBase {
+final class FieldIR extends ElementIRBase {
 
     private final TypeName typeName;
 
@@ -23,7 +23,7 @@ public class FieldIR extends ElementIRBase {
     /**
      * @return get the {@link TypeName} for this field.
      */
-    public TypeName getTypeName() {
+    TypeName getTypeName() {
         return typeName;
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/FieldIR.java
@@ -3,7 +3,8 @@ package com.uber.rave.compiler;
 import com.squareup.javapoet.TypeName;
 
 /**
- * Todo Behrooz.
+ * Represents the intermediate representation (IR) of a field within a particular data model class. This class holds
+ * all the required information to generate a method which verifies the inner fields in a data model.
  */
 public class FieldIR extends ElementIRBase {
 

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/MethodIR.java
@@ -20,69 +20,17 @@
 
 package com.uber.rave.compiler;
 
-import java.lang.annotation.Annotation;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 /**
  * Represents the intermediate representation (IR) of a method within a particular data model class. This class holds
  * all the required information to generate a method which verifies a particular field in a data model.
  */
-final class MethodIR {
-    private final Map<Class<? extends Annotation>, Annotation> annotations;
-    private final String getterName;
+final class MethodIR extends ElementIRBase {
 
     /**
-     * Create a new methodir object.
+     * Create a new method IR object.
      * @param getterName the name of the method getter that this IR represents.
      */
     MethodIR(String getterName) {
-        annotations = new HashMap<>();
-        this.getterName = getterName;
-    }
-
-    /**
-     * Adds a annotation to the method.
-     * @param annotation the annotation to add.
-     */
-    void addAnnotation(Annotation annotation) {
-        annotations.put(annotation.annotationType(), annotation);
-    }
-
-    /**
-     * @return whether the annotations map has any of the RAVE supported annotations.
-     */
-    boolean hasAnyAnnotation() {
-        return annotations.size() > 0;
-    }
-
-    /**
-     * Returns the method name. This is generally the getter method name for some field in the data model class.
-     * @return the string representation of the name.
-     */
-    String getMethodGetterName() {
-        return getterName;
-    }
-
-    /**
-     * A quick lookup to see if the method was annotated with a particular annotation.
-     * @param cls the annoation {@link Class}.
-     * @return true if this method was annotated with the input annotation, false otherwise.
-     */
-    boolean hasAnnotation(Class<? extends Annotation> cls) {
-        return annotations.containsKey(cls);
-    }
-
-    /**
-     * Returns the actual annotation. Null if the method doesn't have that particular annotation.
-     * @param cls the annotation {@link Class}.
-     * @param <A> the generic must extend {@link Annotation}.
-     * @return the annotation or null if the method wasn't annotated with it.
-     */
-    @Nullable
-    <A extends Annotation> A getAnnotation(Class<A> cls) {
-        return (A) annotations.get(cls);
+        super(getterName);
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -190,7 +190,8 @@ public final class RaveProcessor extends AbstractProcessor {
         List<VariableElement> fields = new ImmutableList.Builder<VariableElement>().addAll(
                 ElementFilter.fieldsIn(typeElement.getEnclosedElements())).build();
         for (VariableElement variableElement : fields) {
-            if (variableElement.getModifiers().contains(Modifier.STATIC)) {
+            if (variableElement.getModifiers().contains(Modifier.STATIC)
+                    || variableElement.getAnnotation(Excluded.class) != null) {
                 continue;
             }
             FieldIR fieldIR = new FieldIR(variableElement.getSimpleName().toString(),

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -26,6 +26,7 @@ import android.support.annotation.StringDef;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
+import com.squareup.javapoet.TypeName;
 import com.uber.rave.BaseValidator;
 import com.uber.rave.Validator;
 import com.uber.rave.annotation.Excluded;
@@ -51,6 +52,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.NoType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -154,6 +156,12 @@ public final class RaveProcessor extends AbstractProcessor {
     private ClassIR extractClassInfo(TypeElement typeElement, Validator.Mode mode) {
         ClassIR classIR = new ClassIR(typesUtils.erasure(typeElement.asType()));
         traverseInheritanceTree(typeElement, classIR);
+        buildMethodIR(classIR, typeElement, mode);
+        buildFieldIR(classIR, typeElement, mode);
+        return classIR;
+    }
+
+    private void buildMethodIR(ClassIR classIR, TypeElement typeElement, Validator.Mode mode) {
         List<ExecutableElement> methodElements = new ImmutableList.Builder<ExecutableElement>()
                 .addAll(ElementFilter.methodsIn(typeElement.getEnclosedElements())).build();
         String classPackage = CompilerUtils.packageNameOf(typeElement);
@@ -172,48 +180,69 @@ public final class RaveProcessor extends AbstractProcessor {
                 continue;
             }
             MethodIR methodIR = new MethodIR(executableElement.getSimpleName().toString());
-            for (AnnotationMirror mirror : elementUtils.getAllAnnotationMirrors(executableElement)) {
-                String annotationName = mirror.getAnnotationType().toString();
-                if (CompilerUtils.isSupportAnnotation(mirror.getAnnotationType().toString())) {
-                    Annotation annotation =
-                            executableElement.getAnnotation(CompilerUtils.getSupportAnnotation(annotationName));
-                    methodIR.addAnnotation(annotation);
-                } else if (mirror.getAnnotationType().asElement()
-                        .getSimpleName().toString().toLowerCase().equals("nullable")) {
-                    methodIR.addAnnotation(() -> android.support.annotation.Nullable.class);
-                } else if (mirror.getAnnotationType().asElement()
-                        .getSimpleName().toString().toLowerCase().equals("nonnull")) {
-                    methodIR.addAnnotation(() -> android.support.annotation.NonNull.class);
-                } else {
-                    Annotation annotation = extractDefTypeAnnotations(mirror.getAnnotationType().asElement());
-                    if (annotation != null) {
-                        methodIR.addAnnotation(annotation);
-                    }
-                }
-            }
-            addImplicitNullnessAnnotations(methodIR, mode, executableElement);
+            extractAnnotation(methodIR, executableElement, mode,
+                    !executableElement.getReturnType().getKind().isPrimitive());
             classIR.addMethodIR(methodIR);
         }
-        return classIR;
+    }
+
+    private void buildFieldIR(ClassIR classIR, TypeElement typeElement, Validator.Mode mode) {
+        List<VariableElement> fields = new ImmutableList.Builder<VariableElement>().addAll(
+                ElementFilter.fieldsIn(typeElement.getEnclosedElements())).build();
+        for (VariableElement variableElement : fields) {
+            if (variableElement.getModifiers().contains(Modifier.STATIC)) {
+                continue;
+            }
+            System.out.println(typeElement.getSimpleName().toString() + " Behrooz " + variableElement.asType());
+            FieldIR fieldIR = new FieldIR(variableElement.getSimpleName().toString(),
+                    TypeName.get(variableElement.asType()));
+            extractAnnotation(fieldIR, variableElement, mode, !variableElement.asType().getKind().isPrimitive());
+            classIR.addFieldIR(fieldIR);
+        }
+    }
+
+    private void extractAnnotation(ElementIRBase elementIRBase, Element element, Validator.Mode mode,
+            boolean okToAddNull) {
+        for (AnnotationMirror mirror : elementUtils.getAllAnnotationMirrors(element)) {
+            String annotationName = mirror.getAnnotationType().toString();
+            if (CompilerUtils.isSupportAnnotation(mirror.getAnnotationType().toString())) {
+                Annotation annotation =
+                        element.getAnnotation(CompilerUtils.getSupportAnnotation(annotationName));
+                elementIRBase.addAnnotation(annotation);
+            } else if (mirror.getAnnotationType().asElement()
+                    .getSimpleName().toString().toLowerCase().equals("nullable")) {
+                elementIRBase.addAnnotation(() -> android.support.annotation.Nullable.class);
+            } else if (mirror.getAnnotationType().asElement()
+                    .getSimpleName().toString().toLowerCase().equals("nonnull")) {
+                elementIRBase.addAnnotation(() -> android.support.annotation.NonNull.class);
+            } else {
+                Annotation annotation = extractDefTypeAnnotations(mirror.getAnnotationType().asElement());
+                if (annotation != null) {
+                    elementIRBase.addAnnotation(annotation);
+                }
+            }
+        }
+        addImplicitNullnessAnnotations(elementIRBase, mode, element, okToAddNull);
     }
 
     private void addImplicitNullnessAnnotations(
-            MethodIR methodIR,
+            ElementIRBase elementIRBase,
             Validator.Mode mode,
-            ExecutableElement executableElement) {
-        if (methodIR.hasAnyAnnotation() || executableElement.getReturnType().getKind().isPrimitive()) {
+            Element executableElement,
+            boolean okToAddNull) {
+        if (elementIRBase.hasAnyAnnotation() || !okToAddNull) {
             return;
         }
 
         switch (mode) {
             case DEFAULT:
-                methodIR.addAnnotation(() -> android.support.annotation.Nullable.class);
+                elementIRBase.addAnnotation(() -> android.support.annotation.Nullable.class);
                 break;
             case STRICT:
-                methodIR.addAnnotation(() -> NonNull.class);
+                elementIRBase.addAnnotation(() -> NonNull.class);
                 break;
             default:
-                error(executableElement, "Unhandled validation mode for method: %s", methodIR.getMethodGetterName());
+                error(executableElement, "Unhandled validation mode for method: %s", elementIRBase.getElementName());
         }
     }
 

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveProcessor.java
@@ -193,7 +193,6 @@ public final class RaveProcessor extends AbstractProcessor {
             if (variableElement.getModifiers().contains(Modifier.STATIC)) {
                 continue;
             }
-            System.out.println(typeElement.getSimpleName().toString() + " Behrooz " + variableElement.asType());
             FieldIR fieldIR = new FieldIR(variableElement.getSimpleName().toString(),
                     TypeName.get(variableElement.asType()));
             extractAnnotation(fieldIR, variableElement, mode, !variableElement.asType().getKind().isPrimitive());

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
@@ -186,12 +186,12 @@ final class RaveWriter {
             builder.addStatement("$T $L = getValidationContext($T.class)", BaseValidator.ValidationContext.class,
                     VALIDATION_CONTEXT_ARG_NAME, classIR.getTypeMirror());
             builder.addStatement("$T<$T> $L = null", List.class, RaveError.class, RAVE_ERROR_ARG_NAME);
-            for (FieldIR fieldIR : classIR.getFieldIRs()) {
+            for (FieldIR fieldIR : classIR.getAllFieldIRs()) {
                 if (!fieldIR.hasAnyAnnotation()) {
                     continue;
                 }
                 builder.addParameter(fieldIR.getTypeName(), fieldIR.getElementName());
-                buildAnnotationChecks(builder, fieldIR, AnnotationWriter.WriterType.FIELD);
+                buildAnnotationChecks(builder, fieldIR, AnnotationWriter.WriteType.FIELD);
             }
             builder.beginControlFlow("if ($L != null && !$L.isEmpty())", RAVE_ERROR_ARG_NAME,
                     RAVE_ERROR_ARG_NAME);
@@ -226,7 +226,7 @@ final class RaveWriter {
                     typeUtils.erasure(mirror), VALIDATE_METHOD_ARG_NAME);
         }
         for (MethodIR methodIR : classIR.getAllMethods()) {
-            buildAnnotationChecks(builder, methodIR, AnnotationWriter.WriterType.METHOD);
+            buildAnnotationChecks(builder, methodIR, AnnotationWriter.WriteType.METHOD);
         }
         builder.beginControlFlow("if ($L != null && !$L.isEmpty())", RAVE_ERROR_ARG_NAME,
                 RAVE_ERROR_ARG_NAME);
@@ -236,13 +236,13 @@ final class RaveWriter {
     }
 
     private void buildAnnotationChecks(MethodSpec.Builder builder, ElementIRBase elementIRBase,
-            AnnotationWriter.WriterType writerType) {
+            AnnotationWriter.WriteType writeType) {
         // No check needed for Nullable annotation.
         boolean isNullable = !elementIRBase.hasAnnotation(NonNull.class);
         boolean hasNonNullOrNullable = elementIRBase.hasAnnotation(NonNull.class)
                 || elementIRBase.hasAnnotation(Nullable.class);
         AnnotationWriter writer = new AnnotationWriter(builder, elementIRBase.getElementName(), isNullable,
-                hasNonNullOrNullable, writerType);
+                hasNonNullOrNullable, writeType);
         if (hasNonNullOrNullable && !(elementIRBase.hasAnnotation(Size.class)
                 || elementIRBase.hasAnnotation(StringDef.class))) {
             writer.writeNullable();

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
@@ -45,6 +45,8 @@ import com.uber.rave.annotation.MustBeTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.annotation.Generated;
@@ -64,9 +66,11 @@ final class RaveWriter {
     static final String ADD_SUPPORTED_CLASS_METHOD_NAME = "addSupportedClass";
     static final String RE_EVAL_SUPERTYPE_METHOD_NAME = "reEvaluateAsSuperType";
     static final String MERGE_ERROR_METHOD_NAME = "mergeErrors";
+    static final String INNER_FIELD_METHOD_PREFIX = "validateInternalFor_";
 
     // Arg names.
     static final String VALIDATE_METHOD_ARG_NAME = "object";
+    static final String THIS_ARG_NAME = "this";
     static final String GENERATED_CLASS_POSTFIX = "_Generated_Validator";
     static final Class<? extends Exception> RAVE_INVALID_MODEL_EXCEPTION_CLASS = InvalidModelException.class;
     static final String RAVE_ERROR_ARG_NAME = "raveErrors";
@@ -103,6 +107,7 @@ final class RaveWriter {
     public void generateJava(RaveIR raveIR) throws IOException {
         // Make the main method that calls the private methods of the different types.
         List<MethodSpec> allMethods = generateSubtypeValidationMethods(raveIR);
+        allMethods.addAll(generateStaticFieldValidatorMethods(raveIR));
         allMethods.add(generateConstructor(raveIR));
         String className = raveIR.getSimpleName() + GENERATED_CLASS_POSTFIX;
         TypeSpec.Builder builder = TypeSpec.classBuilder(className);
@@ -167,6 +172,37 @@ final class RaveWriter {
         return allSpecs;
     }
 
+    private Collection<? extends MethodSpec> generateStaticFieldValidatorMethods(RaveIR raveIR) {
+        Collection<MethodSpec> methodSpecCollection = new LinkedList<>();
+        for (ClassIR classIR : raveIR.getClassIRs()) {
+            if (!classIR.hasValidatableFields()) {
+                continue;
+            }
+            String methodNamePostFix = classIR.getTypeMirror().toString().replace(".", "_");
+            MethodSpec.Builder builder = MethodSpec.methodBuilder(INNER_FIELD_METHOD_PREFIX + methodNamePostFix)
+                    .addException(RAVE_INVALID_MODEL_EXCEPTION_CLASS)
+                    .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+                    .returns(void.class);
+            builder.addStatement("$T $L = getValidationContext($T.class)", BaseValidator.ValidationContext.class,
+                    VALIDATION_CONTEXT_ARG_NAME, classIR.getTypeMirror());
+            builder.addStatement("$T<$T> $L = null", List.class, RaveError.class, RAVE_ERROR_ARG_NAME);
+            for (FieldIR fieldIR : classIR.getFieldIRs()) {
+                if (!fieldIR.hasAnyAnnotation()) {
+                    continue;
+                }
+                builder.addParameter(fieldIR.getTypeName(), fieldIR.getElementName());
+                buildAnnotationChecks(builder, fieldIR, AnnotationWriter.WriterType.FIELD);
+            }
+            builder.beginControlFlow("if ($L != null && !$L.isEmpty())", RAVE_ERROR_ARG_NAME,
+                    RAVE_ERROR_ARG_NAME);
+            builder.addStatement("throw new $T($L)", RAVE_INVALID_MODEL_EXCEPTION_CLASS, RAVE_ERROR_ARG_NAME);
+            builder.endControlFlow();
+            methodSpecCollection.add(builder.build());
+        }
+
+        return methodSpecCollection;
+    }
+
     /**
      * Generate a {@link MethodSpec} for a specific type. This generates the private method within the generated class
      * that validates the object as a specific type.
@@ -182,8 +218,7 @@ final class RaveWriter {
                 .addParameter(TypeName.get(classIR.getTypeMirror()), VALIDATE_METHOD_ARG_NAME);
         builder.addStatement("$T $L = getValidationContext($T.class)", BaseValidator.ValidationContext.class,
                 VALIDATION_CONTEXT_ARG_NAME, classIR.getTypeMirror());
-        builder.addStatement("$T<$T> $L = null", List.class, RaveError.class,
-                RAVE_ERROR_ARG_NAME);
+        builder.addStatement("$T<$T> $L = null", List.class, RaveError.class, RAVE_ERROR_ARG_NAME);
         for (TypeMirror mirror : classIR.getInheritedTypes()) {
             // Ex: raveErrors = mergeErrors(reEvaluateAsSuperType(ValidateSample2.class, object), raveErrors);
             builder.addStatement("$L = $L($L, $L($T.class, $L))", RAVE_ERROR_ARG_NAME,
@@ -191,7 +226,7 @@ final class RaveWriter {
                     typeUtils.erasure(mirror), VALIDATE_METHOD_ARG_NAME);
         }
         for (MethodIR methodIR : classIR.getAllMethods()) {
-            buildAnnotationChecks(builder, methodIR);
+            buildAnnotationChecks(builder, methodIR, AnnotationWriter.WriterType.METHOD);
         }
         builder.beginControlFlow("if ($L != null && !$L.isEmpty())", RAVE_ERROR_ARG_NAME,
                 RAVE_ERROR_ARG_NAME);
@@ -200,35 +235,38 @@ final class RaveWriter {
         return builder.build();
     }
 
-    private void buildAnnotationChecks(MethodSpec.Builder builder, MethodIR methodIR) {
+    private void buildAnnotationChecks(MethodSpec.Builder builder, ElementIRBase elementIRBase,
+            AnnotationWriter.WriterType writerType) {
         // No check needed for Nullable annotation.
-        boolean isNullable = !methodIR.hasAnnotation(NonNull.class);
-        boolean hasNonNullOrNullable = methodIR.hasAnnotation(NonNull.class) || methodIR.hasAnnotation(Nullable.class);
-        AnnotationWriter writer = new AnnotationWriter(builder,
-                MethodSpec.methodBuilder(methodIR.getMethodGetterName()).build(), isNullable, hasNonNullOrNullable);
-        if (hasNonNullOrNullable && !(methodIR.hasAnnotation(Size.class) || methodIR.hasAnnotation(StringDef.class))) {
+        boolean isNullable = !elementIRBase.hasAnnotation(NonNull.class);
+        boolean hasNonNullOrNullable = elementIRBase.hasAnnotation(NonNull.class)
+                || elementIRBase.hasAnnotation(Nullable.class);
+        AnnotationWriter writer = new AnnotationWriter(builder, elementIRBase.getElementName(), isNullable,
+                hasNonNullOrNullable, writerType);
+        if (hasNonNullOrNullable && !(elementIRBase.hasAnnotation(Size.class)
+                || elementIRBase.hasAnnotation(StringDef.class))) {
             writer.writeNullable();
         }
-        if (methodIR.hasAnnotation(Size.class)) {
-            writer.write(methodIR.getAnnotation(Size.class));
+        if (elementIRBase.hasAnnotation(Size.class)) {
+            writer.write(elementIRBase.getAnnotation(Size.class));
         }
-        if (methodIR.hasAnnotation(MustBeFalse.class)) {
+        if (elementIRBase.hasAnnotation(MustBeFalse.class)) {
             writer.writeMustBeFalse();
         }
-        if (methodIR.hasAnnotation(MustBeTrue.class)) {
+        if (elementIRBase.hasAnnotation(MustBeTrue.class)) {
             writer.writeMustBeTrue();
         }
-        if (methodIR.hasAnnotation(StringDef.class)) {
-            writer.write(methodIR.getAnnotation(StringDef.class));
+        if (elementIRBase.hasAnnotation(StringDef.class)) {
+            writer.write(elementIRBase.getAnnotation(StringDef.class));
         }
-        if (methodIR.hasAnnotation(IntDef.class)) {
-            writer.write(methodIR.getAnnotation(IntDef.class));
+        if (elementIRBase.hasAnnotation(IntDef.class)) {
+            writer.write(elementIRBase.getAnnotation(IntDef.class));
         }
-        if (methodIR.hasAnnotation(IntRange.class)) {
-            writer.write(methodIR.getAnnotation(IntRange.class));
+        if (elementIRBase.hasAnnotation(IntRange.class)) {
+            writer.write(elementIRBase.getAnnotation(IntRange.class));
         }
-        if (methodIR.hasAnnotation(FloatRange.class)) {
-            writer.write(methodIR.getAnnotation(FloatRange.class));
+        if (elementIRBase.hasAnnotation(FloatRange.class)) {
+            writer.write(elementIRBase.getAnnotation(FloatRange.class));
         }
     }
 }

--- a/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
+++ b/rave-compiler/src/main/java/com/uber/rave/compiler/RaveWriter.java
@@ -70,7 +70,6 @@ final class RaveWriter {
 
     // Arg names.
     static final String VALIDATE_METHOD_ARG_NAME = "object";
-    static final String THIS_ARG_NAME = "this";
     static final String GENERATED_CLASS_POSTFIX = "_Generated_Validator";
     static final Class<? extends Exception> RAVE_INVALID_MODEL_EXCEPTION_CLASS = InvalidModelException.class;
     static final String RAVE_ERROR_ARG_NAME = "raveErrors";

--- a/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
+++ b/rave-compiler/src/test/java/com/uber/rave/compiler/RaveProcessorTest.java
@@ -379,6 +379,32 @@ public class RaveProcessorTest {
     }
 
     @Test
+    public void testFieldMethodValidationGeneration_whenFieldsArePrivate_shouldGenerateAppropriateMethods() {
+        sources.add(JavaFileObjects.forResource("fixtures/fields/comprehensive/SimpleCase.java"));
+        sources.add(JavaFileObjects.forResource("fixtures/fields/FieldsOnlyFactory.java"));
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource(
+                        "fixtures/fields/comprehensive/FieldsOnlyFactory_Generated_Validator.java"));
+    }
+
+    @Test
+    public void testFieldMethodValidationGeneration_whenFieldsArePrivateButNotUsed_shouldNotGenerateMuchValidation() {
+        sources.add(JavaFileObjects.forResource("fixtures/fields/no_gen/NoGen.java"));
+        sources.add(JavaFileObjects.forResource("fixtures/fields/NotStrictFieldsOnlyFactory.java"));
+
+        assertAbout(javaSources()).that(sources)
+                .processedWith(raveProcessor)
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource(
+                        "fixtures/fields/no_gen/NotStrictFieldsOnlyFactory_Generated_Validator.java"));
+    }
+
+    @Test
     public void testExcludedMethod_shouldNotGenerateValidateMethodExcluded() {
         sources.add(JavaFileObjects.forResource("fixtures/excluded/UseOfExcluded.java"));
         sources.add(JavaFileObjects.forResource("fixtures/SampleFactory.java"));

--- a/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/excluded/SampleFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -38,6 +39,19 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getCanBeNullField()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_test1_UseOfExcluded(String notNullField,
+            String canBeNullField) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(UseOfExcluded.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/fields/FieldsOnlyFactory.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/FieldsOnlyFactory.java
@@ -1,0 +1,16 @@
+package fixtures.fields;
+
+import android.support.annotation.NonNull;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.Validator;
+import com.uber.rave.ValidatorFactory;
+
+
+@Validator(mode = Validator.Mode.STRICT)
+public final class FieldsOnlyFactory implements ValidatorFactory {
+    @Override
+    public BaseValidator generateValidator() {
+        return new FieldsOnlyFactory_Generated_Validator();
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/NotStrictFieldsOnlyFactory.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/NotStrictFieldsOnlyFactory.java
@@ -1,0 +1,15 @@
+package fixtures.fields;
+
+import android.support.annotation.NonNull;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.Validator;
+import com.uber.rave.ValidatorFactory;
+
+
+public final class NotStrictFieldsOnlyFactory implements ValidatorFactory {
+    @Override
+    public BaseValidator generateValidator() {
+        return new NotStrictFieldsOnlyFactory_Generated_Validator();
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/comprehensive/FieldsOnlyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/comprehensive/FieldsOnlyFactory_Generated_Validator.java
@@ -1,0 +1,101 @@
+package fixtures.fields;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
+import fixtures.fields.comprehensive.SimpleCase;
+import java.lang.Class;
+import java.lang.IllegalArgumentException;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated(
+        value = "com.uber.rave.compiler.RaveProcessor",
+        comments = "https://github.com/uber-common/rave"
+)
+public final class FieldsOnlyFactory_Generated_Validator extends BaseValidator {
+    FieldsOnlyFactory_Generated_Validator() {
+        addSupportedClass(SimpleCase.class);
+        addSupportedClass(SimpleCase.SomeInnerClass.class);
+        registerSelf();
+    }
+
+    @Override
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
+        if (!clazz.isInstance(object)) {
+            throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
+        }
+        if (clazz.equals(SimpleCase.class)) {
+            validateAs((SimpleCase) object);
+            return;
+        }
+        if (clazz.equals(SimpleCase.SomeInnerClass.class)) {
+            validateAs((SimpleCase.SomeInnerClass) object);
+            return;
+        }
+        throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
+    }
+
+    private void validateAs(SimpleCase object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("getUberPoolState()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getUberPoolState(), "Matched", "Matching", "NotMatched"));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    private void validateAs(SimpleCase.SomeInnerClass object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.SomeInnerClass.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("getString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_fields_comprehensive_SimpleCase(String notNullField,
+            String canBeNullField, String betweenOneAndFive, List<String> names, Integer testIntdef1,
+            int testIntdef2, float testFloatDef, Map<String, SimpleCase> map) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, notNullField, "Matched", "Matching", "NotMatched"));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, false, context));
+        context.setValidatedItemName("betweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, false, context));
+        context.setValidatedItemName("names");
+        raveErrors = mergeErrors(raveErrors, checkNullable(names, false, context));
+        context.setValidatedItemName("testIntdef1");
+        raveErrors = mergeErrors(raveErrors, checkIntDef(context, testIntdef1, false, 1L, 2L, 3L));
+        context.setValidatedItemName("testIntdef2");
+        raveErrors = mergeErrors(raveErrors, checkIntDef(context, testIntdef2, false, 1L, 2L, 3L));
+        context.setValidatedItemName("testFloatDef");
+        raveErrors = mergeErrors(raveErrors, checkFloatRange(context, testFloatDef, 0.1D, 0.5D));
+        context.setValidatedItemName("map");
+        raveErrors = mergeErrors(raveErrors, checkNullable(map, false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_fields_comprehensive_SimpleCase_SomeInnerClass(String someString)
+            throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.SomeInnerClass.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("someString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(someString, false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 import android.support.annotation.StringDef;
 
+import com.uber.rave.annotation.Excluded;
 import com.uber.rave.annotation.MustBeFalse;
 import com.uber.rave.annotation.MustBeTrue;
 import com.uber.rave.annotation.Validated;
@@ -36,6 +37,9 @@ public class SimpleCase {
     @FloatRange(from = .1, to = .5)
     private float testFloatDef;
     private Map<String, SimpleCase> map;
+    @FloatRange(from = .1, to = .5)
+    @Excluded
+    private float shouldExclude;
 
     private static final String MATCHED = "Matched";
     private static final String MATCHING = "Matching";

--- a/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
@@ -38,8 +38,7 @@ public class SimpleCase {
     private float testFloatDef;
     private Map<String, SimpleCase> map;
     @FloatRange(from = .1, to = .5)
-    @Excluded
-    private float shouldExclude;
+    @Excluded private float shouldExclude;
 
     private static final String MATCHED = "Matched";
     private static final String MATCHING = "Matching";

--- a/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/comprehensive/SimpleCase.java
@@ -1,0 +1,83 @@
+package fixtures.fields.comprehensive;
+
+import fixtures.fields.FieldsOnlyFactory;
+
+import android.support.annotation.FloatRange;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+import android.support.annotation.StringDef;
+
+import com.uber.rave.annotation.MustBeFalse;
+import com.uber.rave.annotation.MustBeTrue;
+import com.uber.rave.annotation.Validated;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+import java.util.Map;
+
+@Validated(factory = FieldsOnlyFactory.class)
+public class SimpleCase {
+    private static final String shouldCauseNoGeneration = "";
+
+    @UberPoolState
+    private String notNullField;
+    private String canBeNullField;
+    private String betweenOneAndFive;
+    private final List<String> names;
+    private final boolean isFalse;
+    @IntRestrict
+    private Integer testIntdef1;
+    @IntRestrict
+    private int testIntdef2;
+    private float wontGenerateAnything;
+    @FloatRange(from = .1, to = .5)
+    private float testFloatDef;
+    private Map<String, SimpleCase> map;
+
+    private static final String MATCHED = "Matched";
+    private static final String MATCHING = "Matching";
+    private static final String NOT_MATCHED = "NotMatched";
+
+    @StringDef({MATCHED, MATCHING, NOT_MATCHED})
+    @Retention(RetentionPolicy.SOURCE)
+    @interface UberPoolState { }
+
+    @IntDef({1, 2, 3})
+    @Retention(RetentionPolicy.SOURCE)
+    @interface IntRestrict { }
+
+    public SimpleCase (
+            String notNullField,
+            String canBeNullField,
+            String betweenOneAndFive,
+            List<String> names) {
+        this.notNullField = notNullField;
+        this.canBeNullField = canBeNullField;
+        this.betweenOneAndFive = betweenOneAndFive;
+        this.names = names;
+        isFalse = false;
+    }
+
+    @NonNull
+    public static String staticMethodShouldntGenerateAnything() {
+        return "";
+    };
+
+    @UberPoolState
+    public String getUberPoolState() {
+        return "Hey now";
+    }
+
+    @Validated(factory = FieldsOnlyFactory.class)
+    public static class SomeInnerClass {
+
+        private String someString;
+        public SomeInnerClass() {}
+
+        @NonNull
+        public String getString() { return "someString"; }
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/no_gen/NoGen.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/no_gen/NoGen.java
@@ -1,0 +1,32 @@
+package fixtures.fields.no_gen;
+
+import fixtures.fields.NotStrictFieldsOnlyFactory;
+
+import android.support.annotation.NonNull;
+
+import com.uber.rave.annotation.Validated;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+@Validated(factory = NotStrictFieldsOnlyFactory.class)
+public class NoGen {
+    private static final String shouldCauseNoGeneration = "";
+
+    // These strings should trigger code gen validation code
+    private String notNullField;
+    private String canBeNullField;
+    private String betweenOneAndFive;
+    @NonNull
+    private final List<String> names = new LinkedList<>();
+    private final boolean isFalse = false;
+    private int testIntdef2;
+    private float wontGenerateAnything;
+    // These map should trigger code gen validation code
+    private Map<String, NoGen> map;
+
+    public String getUberPoolState() {
+        return "Hey now";
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/no_gen/NoGen.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/no_gen/NoGen.java
@@ -26,7 +26,7 @@ public class NoGen {
     // These map should trigger code gen validation code
     private Map<String, NoGen> map;
 
-    public String getUberPoolState() {
+    public String getState() {
         return "Hey now";
     }
 }

--- a/rave-compiler/src/test/resources/fixtures/fields/no_gen/NotStrictFieldsOnlyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/no_gen/NotStrictFieldsOnlyFactory_Generated_Validator.java
@@ -1,0 +1,93 @@
+package fixtures.fields;
+
+import com.uber.rave.BaseValidator;
+import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
+import fixtures.fields.no_gen.NoGen;
+import java.lang.Class;
+import java.lang.IllegalArgumentException;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated(
+        value = "com.uber.rave.compiler.RaveProcessor",
+        comments = "https://github.com/uber-common/rave"
+)
+public final class NotStrictFieldsOnlyFactory_Generated_Validator extends BaseValidator {
+    NotStrictFieldsOnlyFactory_Generated_Validator() {
+        addSupportedClass(NoGen.class);
+        addSupportedClass(NoGen.SomeInnerClass.class);
+        registerSelf();
+    }
+
+    @Override
+    protected void validateAs(Object object, Class<?> clazz) throws InvalidModelException {
+        if (!clazz.isInstance(object)) {
+            throw new IllegalArgumentException(object.getClass().getCanonicalName() + "is not of type" + clazz.getCanonicalName());
+        }
+        if (clazz.equals(NoGen.class)) {
+            validateAs((NoGen) object);
+            return;
+        }
+        if (clazz.equals(NoGen.SomeInnerClass.class)) {
+            validateAs((NoGen.SomeInnerClass) object);
+            return;
+        }
+        throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
+    }
+
+    private void validateAs(NoGen object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(NoGen.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("getUberPoolState()");
+        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getUberPoolState(), "Matched", "Matching", "NotMatched"));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    private void validateAs(NoGen.SomeInnerClass object) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(NoGen.SomeInnerClass.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("getString()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_fields_no_gen_NoGen(String notNullField,
+            String canBeNullField, String betweenOneAndFive, List<String> names, Map<String, NoGen> map)
+            throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(NoGen.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
+        context.setValidatedItemName("betweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, true, context));
+        context.setValidatedItemName("names");
+        raveErrors = mergeErrors(raveErrors, checkNullable(names, false, context));
+        context.setValidatedItemName("map");
+        raveErrors = mergeErrors(raveErrors, checkNullable(map, true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_fields_comprehensive_NoGen_SomeInnerClass(String someString)
+            throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(NoGen.SomeInnerClass.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("someString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(someString, false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+}

--- a/rave-compiler/src/test/resources/fixtures/fields/no_gen/NotStrictFieldsOnlyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/fields/no_gen/NotStrictFieldsOnlyFactory_Generated_Validator.java
@@ -20,7 +20,6 @@ import javax.annotation.Generated;
 public final class NotStrictFieldsOnlyFactory_Generated_Validator extends BaseValidator {
     NotStrictFieldsOnlyFactory_Generated_Validator() {
         addSupportedClass(NoGen.class);
-        addSupportedClass(NoGen.SomeInnerClass.class);
         registerSelf();
     }
 
@@ -33,28 +32,14 @@ public final class NotStrictFieldsOnlyFactory_Generated_Validator extends BaseVa
             validateAs((NoGen) object);
             return;
         }
-        if (clazz.equals(NoGen.SomeInnerClass.class)) {
-            validateAs((NoGen.SomeInnerClass) object);
-            return;
-        }
         throw new IllegalArgumentException(object.getClass().getCanonicalName() + " is not supported by validator " + this.getClass().getCanonicalName());
     }
 
     private void validateAs(NoGen object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(NoGen.class);
         List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getUberPoolState()");
-        raveErrors = mergeErrors(raveErrors, checkStringDef(false, context, object.getUberPoolState(), "Matched", "Matching", "NotMatched"));
-        if (raveErrors != null && !raveErrors.isEmpty()) {
-            throw new InvalidModelException(raveErrors);
-        }
-    }
-
-    private void validateAs(NoGen.SomeInnerClass object) throws InvalidModelException {
-        BaseValidator.ValidationContext context = getValidationContext(NoGen.SomeInnerClass.class);
-        List<RaveError> raveErrors = null;
-        context.setValidatedItemName("getString()");
-        raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
+        context.setValidatedItemName("getState()");
+        raveErrors = mergeErrors(raveErrors, checkNullable(object.getState(), true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }
@@ -75,17 +60,6 @@ public final class NotStrictFieldsOnlyFactory_Generated_Validator extends BaseVa
         raveErrors = mergeErrors(raveErrors, checkNullable(names, false, context));
         context.setValidatedItemName("map");
         raveErrors = mergeErrors(raveErrors, checkNullable(map, true, context));
-        if (raveErrors != null && !raveErrors.isEmpty()) {
-            throw new InvalidModelException(raveErrors);
-        }
-    }
-
-    public static void validateInternalFor_fixtures_fields_comprehensive_NoGen_SomeInnerClass(String someString)
-            throws InvalidModelException {
-        BaseValidator.ValidationContext context = getValidationContext(NoGen.SomeInnerClass.class);
-        List<RaveError> raveErrors = null;
-        context.setValidatedItemName("someString");
-        raveErrors = mergeErrors(raveErrors, checkNullable(someString, false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/jsr305/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/jsr305/SampleFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -40,6 +41,19 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getNotNullField(), false, context));
         context.setValidatedItemName("getCanBeNullField()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_jsr305_UseOfJSR305(String notNullField,
+            String canBeNullField) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(UseOfJSR305.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/maps/SampleFactory_Generated_Validator.java
@@ -9,6 +9,7 @@ import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Generated;
 
 @Generated(
@@ -38,6 +39,17 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getMap()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getMap(), true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_maps_ModelWithMap(Map<Object, Object> map) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(ModelWithMap.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("map");
+        raveErrors = mergeErrors(raveErrors, checkNullable(map, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test1/SampleFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -67,6 +68,24 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getString()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getString(), false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_test1_SimpleCase(String notNullField,
+            String canBeNullField, String betweenOneAndFive, List<String> names) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
+        context.setValidatedItemName("betweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, true, context));
+        context.setValidatedItemName("names");
+        raveErrors = mergeErrors(raveErrors, checkNullable(names, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test2/MyFactory_Generated_Validator.java
@@ -10,12 +10,15 @@ import com.uber.rave.model.InheritFrom;
 import com.uber.rave.model.IntDefModel;
 import com.uber.rave.model.IntRangeTestModel;
 import com.uber.rave.model.MultiMethodSampleModel;
+import com.uber.rave.model.NonAnnotated;
 import com.uber.rave.model.SingleMethodSampleModel;
 import com.uber.rave.model.ValidateByInterface;
 import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -193,6 +196,63 @@ public final class MyFactory_Generated_Validator extends BaseValidator {
     List<RaveError> raveErrors = null;
     context.setValidatedItemName("getValue()");
     raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5D, 1000.9D));
+    if (raveErrors != null && !raveErrors.isEmpty()) {
+      throw new InvalidModelException(raveErrors);
+    }
+  }
+
+  public static void validateInternalFor_com_uber_rave_model_InheritFrom(String nonNullString)
+          throws InvalidModelException {
+    BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
+    List<RaveError> raveErrors = null;
+    context.setValidatedItemName("nonNullString");
+    raveErrors = mergeErrors(raveErrors, checkNullable(nonNullString, true, context));
+    if (raveErrors != null && !raveErrors.isEmpty()) {
+      throw new InvalidModelException(raveErrors);
+    }
+  }
+
+  public static void validateInternalFor_com_uber_rave_model_MultiMethodSampleModel(NonAnnotated annotatedObject,
+          String notNullField, String canBeNullField, String betweenOneAndFive,
+          Collection<String> names) throws InvalidModelException {
+    BaseValidator.ValidationContext context = getValidationContext(MultiMethodSampleModel.class);
+    List<RaveError> raveErrors = null;
+    context.setValidatedItemName("annotatedObject");
+    raveErrors = mergeErrors(raveErrors, checkNullable(annotatedObject, true, context));
+    context.setValidatedItemName("notNullField");
+    raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+    context.setValidatedItemName("canBeNullField");
+    raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
+    context.setValidatedItemName("betweenOneAndFive");
+    raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, true, context));
+    context.setValidatedItemName("names");
+    raveErrors = mergeErrors(raveErrors, checkNullable(names, true, context));
+    if (raveErrors != null && !raveErrors.isEmpty()) {
+      throw new InvalidModelException(raveErrors);
+    }
+  }
+
+  public static void validateInternalFor_com_uber_rave_model_SingleMethodSampleModel(String notNullField,
+          String matchStringDef) throws InvalidModelException {
+    BaseValidator.ValidationContext context = getValidationContext(SingleMethodSampleModel.class);
+    List<RaveError> raveErrors = null;
+    context.setValidatedItemName("notNullField");
+    raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+    context.setValidatedItemName("matchStringDef");
+    raveErrors = mergeErrors(raveErrors, checkNullable(matchStringDef, true, context));
+    if (raveErrors != null && !raveErrors.isEmpty()) {
+      throw new InvalidModelException(raveErrors);
+    }
+  }
+
+  public static void validateInternalFor_com_uber_rave_model_ArrayNotNull(String[] strings,
+          Collection<SingleMethodSampleModel> singles) throws InvalidModelException {
+    BaseValidator.ValidationContext context = getValidationContext(ArrayNotNull.class);
+    List<RaveError> raveErrors = null;
+    context.setValidatedItemName("strings");
+    raveErrors = mergeErrors(raveErrors, checkNullable(strings, true, context));
+    context.setValidatedItemName("singles");
+    raveErrors = mergeErrors(raveErrors, checkNullable(singles, true, context));
     if (raveErrors != null && !raveErrors.isEmpty()) {
       throw new InvalidModelException(raveErrors);
     }

--- a/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test3/SampleFactory_Generated_Validator.java
@@ -12,6 +12,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -115,6 +116,35 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getNotNullField()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNotNullField(), true, 1L, 5L, 1L, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_test3_ValidateSample(String notNullField,
+            String canBeNullField, String betweenOneAndFive, List<String> names) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(ValidateSample.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
+        context.setValidatedItemName("betweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, true, context));
+        context.setValidatedItemName("names");
+        raveErrors = mergeErrors(raveErrors, checkNullable(names, true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_test3_ValidateSample2(String notNullField) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(ValidateSample2.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/test4/SampleFactory_Generated_Validator.java
@@ -10,6 +10,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -70,6 +71,17 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         raveErrors = mergeErrors(raveErrors, reEvaluateAsSuperType(ValidateByInterface.class, object));
         context.setValidatedItemName("getNonNullString()");
         raveErrors = mergeErrors(raveErrors, isSizeOk(object.getNonNullString(), true, 1L, 5L, 1L, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_test4_ValidateSample2(String notNullField) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(ValidateSample2.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/unannotated/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/unannotated/SampleFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -38,6 +39,17 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getNullableField()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getNullableField(), true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_unannotated_UnannotatedField(String nullableField)
+            throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(UnannotatedField.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("nullableField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(nullableField, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/validationstrategy/simple/StrictModeFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -42,6 +43,21 @@ public final class StrictModeFactory_Generated_Validator extends BaseValidator {
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getCanBeNullField(), true, context));
         context.setValidatedItemName("getUnannotatedField()");
         raveErrors = mergeErrors(raveErrors, checkNullable(object.getUnannotatedField(), false, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_validationstrategy_simple_SimpleCase(String notNullField,
+            String canBeNullField, String unannotatedField) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SimpleCase.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, false, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, false, context));
+        context.setValidatedItemName("unannotatedField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(unannotatedField, false, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
+++ b/rave-compiler/src/test/resources/fixtures/voidreturn/SampleFactory_Generated_Validator.java
@@ -8,6 +8,7 @@ import java.lang.Class;
 import java.lang.IllegalArgumentException;
 import java.lang.Object;
 import java.lang.Override;
+import java.lang.String;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -36,6 +37,17 @@ public final class SampleFactory_Generated_Validator extends BaseValidator {
     private void validateAs(VoidReturn object) throws InvalidModelException {
         BaseValidator.ValidationContext context = getValidationContext(VoidReturn.class);
         List<RaveError> raveErrors = null;
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_fixtures_voidreturn_VoidReturn(String test) throws
+            InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(VoidReturn.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("test");
+        raveErrors = mergeErrors(raveErrors, checkNullable(test, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/rave/src/main/java/com/uber/rave/BaseValidator.java
+++ b/rave/src/main/java/com/uber/rave/BaseValidator.java
@@ -696,7 +696,7 @@ public abstract class BaseValidator {
     public static final class ValidationContext {
 
         private final Class<?> clazz;
-        private String validatedjItemName = "";
+        private String validatedItemName = "";
 
         private ValidationContext(Class<?> clazz) {
             this.clazz = clazz;

--- a/rave/src/main/java/com/uber/rave/BaseValidator.java
+++ b/rave/src/main/java/com/uber/rave/BaseValidator.java
@@ -696,7 +696,7 @@ public abstract class BaseValidator {
     public static final class ValidationContext {
 
         private final Class<?> clazz;
-        private String validatedItemName = "";
+        private String validatedjItemName = "";
 
         private ValidationContext(Class<?> clazz) {
             this.clazz = clazz;

--- a/rave/src/main/java/com/uber/rave/annotation/Excluded.java
+++ b/rave/src/main/java/com/uber/rave/annotation/Excluded.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 public @interface Excluded { }

--- a/rave/src/main/java/com/uber/rave/annotation/MustBeFalse.java
+++ b/rave/src/main/java/com/uber/rave/annotation/MustBeFalse.java
@@ -29,6 +29,6 @@ import java.lang.annotation.Target;
  * Annotation to denote that some function must return false. These can be used to assert conditions on a method return
  * type.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.SOURCE)
 public @interface MustBeFalse { }

--- a/rave/src/main/java/com/uber/rave/annotation/MustBeTrue.java
+++ b/rave/src/main/java/com/uber/rave/annotation/MustBeTrue.java
@@ -29,6 +29,6 @@ import java.lang.annotation.Target;
  * Annotation to denote that some function must return false. These can be used to assert conditions on a method return
  * type.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.SOURCE)
 public @interface MustBeTrue { }

--- a/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
+++ b/rave/src/test/java/com/uber/rave/model/TestFactory_Generated_Validator.java
@@ -3,9 +3,10 @@ package com.uber.rave.model;
 import android.support.annotation.NonNull;
 
 import com.uber.rave.BaseValidator;
-import com.uber.rave.RaveError;
 import com.uber.rave.InvalidModelException;
+import com.uber.rave.RaveError;
 
+import java.util.Collection;
 import java.util.List;
 
 public final class TestFactory_Generated_Validator extends BaseValidator {
@@ -185,6 +186,63 @@ public final class TestFactory_Generated_Validator extends BaseValidator {
         List<RaveError> raveErrors = null;
         context.setValidatedItemName("getValue()");
         raveErrors = mergeErrors(raveErrors, checkFloatRange(context, object.getValue(), -15.5d, 1000.9d));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_com_uber_rave_model_InheritFrom(String nonNullString)
+            throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(InheritFrom.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("nonNullString");
+        raveErrors = mergeErrors(raveErrors, checkNullable(nonNullString, true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_com_uber_rave_model_MultiMethodSampleModel(NonAnnotated annotatedObject,
+            String notNullField, String canBeNullField, String betweenOneAndFive,
+            Collection<String> names) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(MultiMethodSampleModel.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("annotatedObject");
+        raveErrors = mergeErrors(raveErrors, checkNullable(annotatedObject, true, context));
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("canBeNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(canBeNullField, true, context));
+        context.setValidatedItemName("betweenOneAndFive");
+        raveErrors = mergeErrors(raveErrors, checkNullable(betweenOneAndFive, true, context));
+        context.setValidatedItemName("names");
+        raveErrors = mergeErrors(raveErrors, checkNullable(names, true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_com_uber_rave_model_SingleMethodSampleModel(String notNullField,
+            String matchStringDef) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(SingleMethodSampleModel.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("notNullField");
+        raveErrors = mergeErrors(raveErrors, checkNullable(notNullField, true, context));
+        context.setValidatedItemName("matchStringDef");
+        raveErrors = mergeErrors(raveErrors, checkNullable(matchStringDef, true, context));
+        if (raveErrors != null && !raveErrors.isEmpty()) {
+            throw new InvalidModelException(raveErrors);
+        }
+    }
+
+    public static void validateInternalFor_com_uber_rave_model_ArrayNotNull(String[] strings,
+            Collection<SingleMethodSampleModel> singles) throws InvalidModelException {
+        BaseValidator.ValidationContext context = getValidationContext(ArrayNotNull.class);
+        List<RaveError> raveErrors = null;
+        context.setValidatedItemName("strings");
+        raveErrors = mergeErrors(raveErrors, checkNullable(strings, true, context));
+        context.setValidatedItemName("singles");
+        raveErrors = mergeErrors(raveErrors, checkNullable(singles, true, context));
         if (raveErrors != null && !raveErrors.isEmpty()) {
             throw new InvalidModelException(raveErrors);
         }

--- a/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
+++ b/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
@@ -2,16 +2,25 @@ package com.uber.rave.sample.network.model;
 
 import android.support.annotation.NonNull;
 
+import com.uber.rave.annotation.MustBeTrue;
 import com.uber.rave.annotation.Validated;
 import com.uber.rave.sample.network.RaveValidatorFactory;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Validated(factory = RaveValidatorFactory.class)
 public class Owner implements Serializable {
-
+    private static final String finalstring = "";
     @NonNull private String login;
+    @MustBeTrue private boolean field2;
+    private final List<Owner> list = null;
     private int id;
+
+    public Owner() {
+        login = "";
+        field2 = false;
+    }
 
     @NonNull
     public String getLogin() {

--- a/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
+++ b/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
@@ -8,7 +8,6 @@ import com.uber.rave.annotation.Validated;
 import com.uber.rave.sample.network.RaveValidatorFactory;
 import com.uber.rave.sample.network.RaveValidatorFactory_Generated_Validator;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 

--- a/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
+++ b/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
@@ -8,6 +8,7 @@ import com.uber.rave.annotation.Validated;
 import com.uber.rave.sample.network.RaveValidatorFactory;
 import com.uber.rave.sample.network.RaveValidatorFactory_Generated_Validator;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
@@ -59,6 +60,8 @@ public class Owner implements Serializable {
         return result;
     }
 
+    // This is an example of how you can check inner fields that are protected or private. We will soon eliminat the
+    // need to even do this in later RAVE releases.
     @MustBeTrue
     public boolean validateFields() throws InvalidModelException {
         RaveValidatorFactory_Generated_Validator.validateInternalFor_com_uber_rave_sample_network_model_Owner(login,

--- a/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
+++ b/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
@@ -2,9 +2,11 @@ package com.uber.rave.sample.network.model;
 
 import android.support.annotation.NonNull;
 
+import com.uber.rave.InvalidModelException;
 import com.uber.rave.annotation.MustBeTrue;
 import com.uber.rave.annotation.Validated;
 import com.uber.rave.sample.network.RaveValidatorFactory;
+import com.uber.rave.sample.network.RaveValidatorFactory_Generated_Validator;
 
 import java.io.Serializable;
 import java.util.List;
@@ -55,5 +57,12 @@ public class Owner implements Serializable {
         int result = login != null ? login.hashCode() : 0;
         result = 31 * result + id;
         return result;
+    }
+
+    @MustBeTrue
+    public boolean validateFields() throws InvalidModelException {
+        RaveValidatorFactory_Generated_Validator.validateInternalFor_com_uber_rave_sample_network_model_Owner(login,
+                field2, list);
+        return true;
     }
 }

--- a/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
+++ b/sample/src/main/java/com/uber/rave/sample/network/model/Owner.java
@@ -2,27 +2,16 @@ package com.uber.rave.sample.network.model;
 
 import android.support.annotation.NonNull;
 
-import com.uber.rave.InvalidModelException;
-import com.uber.rave.annotation.MustBeTrue;
 import com.uber.rave.annotation.Validated;
 import com.uber.rave.sample.network.RaveValidatorFactory;
-import com.uber.rave.sample.network.RaveValidatorFactory_Generated_Validator;
 
 import java.io.Serializable;
-import java.util.List;
 
 @Validated(factory = RaveValidatorFactory.class)
 public class Owner implements Serializable {
-    private static final String finalstring = "";
-    @NonNull private String login;
-    @MustBeTrue private boolean field2;
-    private final List<Owner> list = null;
-    private int id;
 
-    public Owner() {
-        login = "";
-        field2 = false;
-    }
+    @NonNull private String login;
+    private int id;
 
     @NonNull
     public String getLogin() {
@@ -57,14 +46,5 @@ public class Owner implements Serializable {
         int result = login != null ? login.hashCode() : 0;
         result = 31 * result + id;
         return result;
-    }
-
-    // This is an example of how you can check inner fields that are protected or private. We will soon eliminat the
-    // need to even do this in later RAVE releases.
-    @MustBeTrue
-    public boolean validateFields() throws InvalidModelException {
-        RaveValidatorFactory_Generated_Validator.validateInternalFor_com_uber_rave_sample_network_model_Owner(login,
-                field2, list);
-        return true;
     }
 }


### PR DESCRIPTION
Starts to address #44 This pull request modifies the generated validators to generate code that allows models to self validate their inner fields. The same logic that is used to validate the methods applies here. With this change you can add a method to your model (example in sample app) that will validate everything when you run rave over you model. 